### PR TITLE
Make it possible to evaluate stdlib

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -298,6 +298,16 @@ type astIndex struct {
 	id     *identifier
 }
 
+type astSlice struct {
+	astNodeBase
+	target astNode
+
+	// Each of these can be nil
+	beginIndex astNode
+	endIndex   astNode
+	step       astNode
+}
+
 // ---------------------------------------------------------------------------
 
 // astLocalBind is a helper struct for astLocal
@@ -380,6 +390,7 @@ const (
 	astObjectFieldVisible                           // f::: e
 )
 
+// TODO(sbarzowski) consider having separate types for various kinds
 type astObjectField struct {
 	kind          astObjectFieldKind
 	hide          astObjectFieldHide // (ignore if kind != astObjectField*)

--- a/parser.go
+++ b/parser.go
@@ -962,24 +962,24 @@ func (p *parser) parse(prec precedence) (astNode, error) {
 			case tokenBracketL:
 				// handle slice
 				var indexes [3]astNode
-				which := 0
+				colonsConsumed := 0
 
 				var end *token
 				readyForNextIndex := true
-				for which < 3 {
+				for colonsConsumed < 3 {
 					if p.peek().kind == tokenBracketR {
 						end = p.pop()
 						break
 					} else if p.peek().data == ":" {
-						which++
+						colonsConsumed++
 						end = p.pop()
 						readyForNextIndex = true
 					} else if p.peek().data == "::" {
-						which += 2
+						colonsConsumed += 2
 						end = p.pop()
 						readyForNextIndex = true
 					} else if readyForNextIndex {
-						indexes[which], err = p.parse(maxPrecedence)
+						indexes[colonsConsumed], err = p.parse(maxPrecedence)
 						if err != nil {
 							return nil, err
 						}
@@ -988,15 +988,15 @@ func (p *parser) parse(prec precedence) (astNode, error) {
 						return nil, p.unexpectedTokenError(tokenBracketR, p.peek())
 					}
 				}
-				if which > 2 {
+				if colonsConsumed > 2 {
 					// example: target[42:42:42:42]
 					return p.parsingFailure("Invalid slice: too many colons", end)
 				}
-				if which == 0 && readyForNextIndex {
+				if colonsConsumed == 0 && readyForNextIndex {
 					// example: target[]
 					return p.parsingFailure("Index requires an expression", end)
 				}
-				isSlice := which > 0
+				isSlice := colonsConsumed > 0
 
 				if isSlice {
 					lhs = &astSlice{

--- a/parser.go
+++ b/parser.go
@@ -84,11 +84,17 @@ func (p *parser) pop() *token {
 	return t
 }
 
+func (p *parser) unexpectedTokenError(tk tokenKind, t *token) error {
+	if tk == t.kind {
+		panic("Unexpectedly expected token kind.")
+	}
+	return makeStaticError(fmt.Sprintf("Expected token %v but got %v", tk, t), t.loc)
+}
+
 func (p *parser) popExpect(tk tokenKind) (*token, error) {
 	t := p.pop()
 	if t.kind != tk {
-		return nil, makeStaticError(
-			fmt.Sprintf("Expected token %v but got %v", tk, t), t.loc)
+		return nil, p.unexpectedTokenError(tk, t)
 	}
 	return t, nil
 }
@@ -721,6 +727,10 @@ func (p *parser) parseTerminal() (astNode, error) {
 	return nil, makeStaticError(fmt.Sprintf("INTERNAL ERROR: Unknown tok kind: %v", tok.kind), tok.loc)
 }
 
+func (p *parser) parsingFailure(msg string, tok *token) (astNode, error) {
+	return nil, makeStaticError(msg, tok.loc)
+}
+
 func (p *parser) parse(prec precedence) (astNode, error) {
 	begin := p.peek()
 
@@ -923,6 +933,12 @@ func (p *parser) parse(prec precedence) (astNode, error) {
 					// assert AST.
 					return lhs, nil
 				}
+				if p.peek().data == "::" {
+					// Special case for [e::]
+					// We need to stop parsing e when we see the :: and
+					// avoid tripping the op_is_binary test below.
+					return lhs, nil
+				}
 				var ok bool
 				bop, ok = bopMap[p.peek().data]
 				if !ok {
@@ -944,18 +960,58 @@ func (p *parser) parse(prec precedence) (astNode, error) {
 			op := p.pop()
 			switch op.kind {
 			case tokenBracketL:
-				index, err := p.parse(maxPrecedence)
-				if err != nil {
-					return nil, err
+				// handle slice
+				var indexes [3]astNode
+				which := 0
+
+				var end *token
+				readyForNextIndex := true
+				for which < 3 {
+					if p.peek().kind == tokenBracketR {
+						end = p.pop()
+						break
+					} else if p.peek().data == ":" {
+						which++
+						end = p.pop()
+						readyForNextIndex = true
+					} else if p.peek().data == "::" {
+						which += 2
+						end = p.pop()
+						readyForNextIndex = true
+					} else if readyForNextIndex {
+						indexes[which], err = p.parse(maxPrecedence)
+						if err != nil {
+							return nil, err
+						}
+						readyForNextIndex = false
+					} else {
+						return nil, p.unexpectedTokenError(tokenBracketR, p.peek())
+					}
 				}
-				end, err := p.popExpect(tokenBracketR)
-				if err != nil {
-					return nil, err
+				if which > 2 {
+					// example: target[42:42:42:42]
+					return p.parsingFailure("Invalid slice: too many colons", end)
 				}
-				lhs = &astIndex{
-					astNodeBase: astNodeBase{loc: locFromTokens(begin, end)},
-					target:      lhs,
-					index:       index,
+				if which == 0 && readyForNextIndex {
+					// example: target[]
+					return p.parsingFailure("Index requires an expression", end)
+				}
+				isSlice := which > 0
+
+				if isSlice {
+					lhs = &astSlice{
+						astNodeBase: astNodeBase{loc: locFromTokens(begin, end)},
+						target:      lhs,
+						beginIndex:  indexes[0],
+						endIndex:    indexes[1],
+						step:        indexes[2],
+					}
+				} else {
+					lhs = &astIndex{
+						astNodeBase: astNodeBase{loc: locFromTokens(begin, end)},
+						target:      lhs,
+						index:       indexes[0],
+					}
 				}
 			case tokenDot:
 				fieldID, err := p.popExpect(tokenIdentifier)

--- a/parser_test.go
+++ b/parser_test.go
@@ -15,7 +15,9 @@ limitations under the License.
 */
 package jsonnet
 
-import "testing"
+import (
+	"testing"
+)
 
 var tests = []string{
 	`true`,
@@ -88,6 +90,23 @@ var tests = []string{
 
 	`{a: b} + {c: d}`,
 	`{a: b}{c: d}`,
+
+	// no colons
+	`[][0]`,
+	// one colon
+	`[][:]`,
+	`[][1:]`,
+	`[][:1]`,
+	`[][1:2]`,
+	// two colons
+	`[][::]`,
+	`[][1::]`,
+	`[][:1:]`,
+	`[][::1]`,
+	`[][1:1:]`,
+	`[][:1:1]`,
+	`[][1::1]`,
+	`[][1:1:1]`,
 }
 
 func TestParser(t *testing.T) {
@@ -201,6 +220,9 @@ var errorTests = []testError{
 
 	{`a[(b c)]`, `test:1:6-7 Expected token ")" but got (IDENTIFIER, "c")`},
 	{`a[b c]`, `test:1:5-6 Expected token "]" but got (IDENTIFIER, "c")`},
+	{`a[]`, `test:1:3-4 Index requires an expression`},
+	{`a[42:42:42:42]`, `test:1:11-12 Invalid slice: too many colons`},
+	{`a[42:42::42]`, `test:1:8-10 Invalid slice: too many colons`},
 
 	{`a{b c}`, `test:1:5-6 Expected token OPERATOR but got (IDENTIFIER, "c")`},
 }

--- a/tests.sh
+++ b/tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 source tests_path.source
 export DISABLE_EXT_PARAMS=true
 export DISABLE_LIB_TESTS=true


### PR DESCRIPTION
New features in parser and desugarer:
* Support for slices
* Support for methods
* Support for function sugar in locals
* Prevent crashes with obj/arr comprehensions

After this change evaluating stdlib doesn't crash.