### PR TITLE
initialize the extMap

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func MakeVM() *VM {
 	return &VM{
 		MaxStack: 500,
 		MaxTrace: 20,
+		ext:      make(vmExtMap),
 	}
 }
 


### PR DESCRIPTION
Given the following scenario

	vm := jsonnet.MakeVM()
	vm.ExtVar("foo", "bar")

calling the `ExtVar` and `ExtCode` methods of a vm result in a panic
because the map has not been initialized, this patch adds
initializes the map.

Signed-off-by: Sevki <s@sevki.org>