### PR TITLE
Separate manifestation from serialization to string

### DIFF
--- a/builtins.go
+++ b/builtins.go
@@ -17,7 +17,6 @@ limitations under the License.
 package jsonnet
 
 import (
-	"bytes"
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
@@ -241,12 +240,11 @@ func builtinToString(e *evaluator, xp potentialValue) (value, error) {
 	case *valueString:
 		return x, nil
 	}
-	var buf bytes.Buffer
-	err = e.i.manifestJSON(e.trace, x, false, "", &buf)
+	s, err := e.i.manifestAndSerializeJSON(e.trace, x, false, "")
 	if err != nil {
 		return nil, err
 	}
-	return makeValueString(buf.String()), nil
+	return makeValueString(s), nil
 }
 
 func builtinMakeArray(e *evaluator, szp potentialValue, funcp potentialValue) (value, error) {

--- a/interpreter.go
+++ b/interpreter.go
@@ -692,10 +692,6 @@ func serializeJSON(v interface{}, multiline bool, indent string, buf *bytes.Buff
 	}
 }
 
-// TODO(sbarzowski) Perhaps it should be a builtin?
-// TODO(sbarzowski) Perhaps we should separate recursive evaluation from serialization?
-// 					Strictly evaluating something may be useful by itself.
-//					For example may help with error reporting from custom serialization functions.
 func (i *interpreter) manifestAndSerializeJSON(trace *TraceElement, v value, multiline bool, indent string) (string, error) {
 	var buf bytes.Buffer
 	manifested, err := i.manifestJSON(trace, v)


### PR DESCRIPTION
This is necessary for example for native functions
(which take json as arguments).

Standard "encoding/json" representation is used, but I have
mixed feeling about it. Not sure if treating json values as interface{}
is the right trade-off in our case.