### PR TITLE
Remove go:generate causing errors

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -25,5 +25,3 @@ text.
 See http://jsonnet.org/ for a full language description and tutorial.
 */
 package jsonnet
-
-//go:generate gen


### PR DESCRIPTION
```
No types marked with +gen were found. See http://clipperhouse.github.io/gen to get started, or type /tmp/go-build675261218/command-line-arguments/_obj/exe/main help.
exit status 1
doc.go:29: running "gen": exit status 1
```