### PR TITLE
experiment dump ast to source code

### DIFF
--- a/builtins.go
+++ b/builtins.go
@@ -28,8 +28,8 @@ import (
 
 // TODO(sbarzowski) Is this the best option? It's the first one that worked for me...
 //go:generate esc -o std.go -pkg=jsonnet std/std.jsonnet
-
-func getStdCode() string {
+//go:generate go run cmd/dumpstdlibast.go
+func GetStdCode() string {
 	return FSMustString(false, "/std/std.jsonnet")
 }
 

--- a/cmd/dumpstdlibast.go
+++ b/cmd/dumpstdlibast.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2017 Google Inc. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	"github.com/google/go-jsonnet"
+	"github.com/google/go-jsonnet/dump"
+)
+
+func main() {
+	filename := "ast/stdast.go"
+
+	file, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE,0644)
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+
+	node, err := jsonnet.SnippetToAST("<std>", jsonnet.GetStdCode())
+	if err != nil {
+		panic(err)
+	}
+
+	dump.Config.HidePrivateFields = false
+	dump.Config.StripPackageNames = true
+	dump.Config.VariableName = "StdAst"
+	ast := dump.Sdump(node)
+
+	file.WriteString("package ast\n\n")
+	file.WriteString(ast)
+	file.Sync()
+}

--- a/dump/README.md
+++ b/dump/README.md
@@ -1,0 +1,72 @@
+# dump
+
+Package dump can dump a Go data structure to Go source file, so that it can be statically embeded into other code.
+
+# Project Status
+* UnsafePointer is not supported yet
+* cyclic pointer is not supported yet
+
+# Implementation Notes
+
+## Aliase
+
+Primitive pointer and reused pointer will be aliased.
+
+### Primitive pointers
+```go
+var a = "hello world"
+
+var Obj = &struct {
+    Foo *string
+    Bar *string
+}{
+	Foo: &a,
+	Bar: &a,
+}
+
+dump.dump(Obj)
+
+```
+
+will output
+```go
+var p1Var = "hello world"
+var p1 = &p1Var
+var Obj = &struct { Foo *string; Bar *string }{
+	Foo: p1,
+	Bar: p1,
+}
+```
+
+### Reused pointers
+```go
+type Zeo struct {
+	A *string
+}
+
+var z = Zeo {
+	A: "hello world",
+}
+
+var Obj = &struct {
+	Foo *Zeo
+	Bar *Zeo
+}{
+	Foo: &z,
+	Bar: &z,
+}
+
+dump.dump(Obj)
+```
+
+will output
+
+```go
+var p1 = &Zeo{
+	A: "hello world",
+}
+var Obj = &struct { Foo *Zeo; Bar *Zeo }{
+	Foo: p1,
+	Bar: p1,
+}
+```

--- a/dump/README.md
+++ b/dump/README.md
@@ -4,13 +4,13 @@ Package dump can dump a Go data structure to Go source file, so that it can be s
 
 # Project Status
 * UnsafePointer is not supported yet
-* cyclic pointer is not supported yet
+* Cycles in the object graph are not supported yet
 
 # Implementation Notes
 
-## Aliase
+## Aliasing
 
-Primitive pointer and reused pointer will be aliased.
+Aliases to primitives and structs will be preserved in the objects described by the generated code.
 
 ### Primitive pointers
 ```go

--- a/dump/dump.go
+++ b/dump/dump.go
@@ -1,0 +1,510 @@
+/*
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+package dump
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"regexp"
+	"sort"
+	"strconv"
+)
+
+var packageNameStripperRegexp = regexp.MustCompile("\\b[a-zA-Z_]+[a-zA-Z_0-9]+\\.")
+
+// Options represents configuration options for litter
+type Options struct {
+	StripPackageNames bool
+	HidePrivateFields bool
+	HomePackage       string
+	VariableName 	  string
+}
+
+// Config is the default config used when calling Dump
+var Config = Options{
+	StripPackageNames: false,
+	HidePrivateFields: true,
+	VariableName: "p0",
+}
+
+type dumpState struct {
+	w      io.Writer
+	depth  int
+	config *Options
+
+	allPointers     []uintptr
+	visitedPointers []uintptr
+
+	reusedPointers    []uintptr
+	primitivePointers []uintptr
+
+	currentPointerName string
+	homePackageRegexp  *regexp.Regexp
+}
+
+func (s *dumpState) indent() {
+	s.w.Write(bytes.Repeat([]byte("\t"), s.depth))
+}
+
+func (s *dumpState) newline() {
+	s.w.Write([]byte("\n"))
+}
+
+func (s *dumpState) dumpType(v reflect.Value) {
+	typeName := v.Type().String()
+	if s.config.StripPackageNames {
+		typeName = packageNameStripperRegexp.ReplaceAllLiteralString(typeName, "")
+	} else if s.homePackageRegexp != nil {
+		typeName = s.homePackageRegexp.ReplaceAllLiteralString(typeName, "")
+	}
+	s.w.Write([]byte(typeName))
+}
+
+func (s *dumpState) dumpSlice(v reflect.Value) {
+	s.dumpType(v)
+	numEntries := v.Len()
+	if numEntries == 0 {
+		s.w.Write([]byte("{}"))
+		s.newline()
+		return
+	}
+	s.w.Write([]byte("{"))
+	s.newline()
+	s.depth++
+	for i := 0; i < numEntries; i++ {
+		s.indent()
+		s.dumpVal(v.Index(i))
+		s.w.Write([]byte(","))
+		s.newline()
+	}
+	s.depth--
+	s.indent()
+	s.w.Write([]byte("}"))
+}
+
+func (s *dumpState) dumpStruct(v reflect.Value) {
+	dumpPreamble := func() {
+		s.dumpType(v)
+		s.w.Write([]byte("{"))
+		s.newline()
+		s.depth++
+	}
+	preambleDumped := false
+	vt := v.Type()
+	numFields := v.NumField()
+	for i := 0; i < numFields; i++ {
+		vtf := vt.Field(i)
+		if s.config.HidePrivateFields && vtf.PkgPath != "" {
+			continue
+		}
+		if !preambleDumped {
+			dumpPreamble()
+			preambleDumped = true
+		}
+		s.indent()
+		s.w.Write([]byte(vtf.Name))
+		s.w.Write([]byte(": "))
+		s.dumpVal(v.Field(i))
+		s.w.Write([]byte(","))
+		s.newline()
+	}
+	if preambleDumped {
+		s.depth--
+		s.indent()
+		s.w.Write([]byte("}"))
+	} else {
+		// There were no fields dumped
+		s.dumpType(v)
+		s.w.Write([]byte("{}"))
+	}
+}
+
+func (s *dumpState) dumpMap(v reflect.Value) {
+	s.dumpType(v)
+	s.w.Write([]byte("{"))
+	s.newline()
+	s.depth++
+	keys := v.MapKeys()
+	sort.Sort(mapKeySorter{keys})
+	for _, key := range keys {
+		s.indent()
+		s.dumpVal(key)
+		s.w.Write([]byte(": "))
+		s.dumpVal(v.MapIndex(key))
+		s.w.Write([]byte(","))
+		s.newline()
+	}
+	s.depth--
+	s.indent()
+	s.w.Write([]byte("}"))
+}
+
+func (s *dumpState) dump(value interface{}) {
+	if value == nil {
+		s.w.Write([]byte("var" + s.config.VariableName + "=" ))
+		printNil(s.w)
+		return
+	}
+	v := reflect.ValueOf(value)
+
+	s.dumpPrimitivePointerVal(v)
+	s.visitedPointers = []uintptr{}
+
+	s.dumpReusedPointerVal(v)
+
+	s.w.Write([]byte("var " + s.config.VariableName + " = " ))
+	if v.Kind() == reflect.Ptr && v.IsNil(){
+			printNil(s.w)
+	}
+	s.dumpVal(v)
+}
+
+func (s *dumpState) printPrimitivePointer(value reflect.Value, pointerName string) {
+	v := deInterface(value)
+
+	s.w.Write([]byte("var " + pointerName + "Var" + " = "))
+	switch v.Kind() {
+	case reflect.Bool:
+		printBool(s.w, v.Bool())
+
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
+		printInt(s.w, v.Int(), 10)
+
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
+		printUint(s.w, v.Uint(), 10)
+
+	case reflect.Float32:
+		printFloat(s.w, v.Float(), 32)
+
+	case reflect.Float64:
+		printFloat(s.w, v.Float(), 64)
+
+	case reflect.Complex64:
+		printComplex(s.w, v.Complex(), 32)
+
+	case reflect.Complex128:
+		printComplex(s.w, v.Complex(), 64)
+
+	case reflect.String:
+		s.w.Write([]byte(strconv.Quote(v.String())))
+	}
+
+	s.newline()
+	s.w.Write([]byte("var " + pointerName + " = &" + pointerName + "Var"))
+	s.newline()
+}
+
+func (s *dumpState) dumpPrimitivePointerVal(value reflect.Value) {
+	if value.Kind() == reflect.Ptr && value.IsNil() {
+		return
+	}
+	v := deInterface(value)
+	kind := v.Kind()
+
+	switch kind {
+	case reflect.Invalid:
+		// Do nothing.  We should never get here since invalid has already
+		// been handled above.
+		s.w.Write([]byte("<invalid>"))
+
+	case reflect.Slice:
+		if v.IsNil() {
+			break
+		}
+		fallthrough
+
+	case reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			s.dumpPrimitivePointerVal(v.Index(i))
+		}
+
+	case reflect.Map:
+		keys := v.MapKeys()
+		sort.Sort(mapKeySorter{keys})
+		for _, key := range keys {
+			s.dumpPrimitivePointerVal(v.MapIndex(key))
+		}
+
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			s.dumpPrimitivePointerVal(v.Field(i))
+		}
+
+	case reflect.Ptr:
+		pointerName, isPrimitive, isFirstVisit := s.nameForPointer(v), s.isPrimitivePointer(v), s.visitPointerAndCheckIfFirstTime(v)
+		if isPrimitive && isFirstVisit {
+			s.printPrimitivePointer(v.Elem(), pointerName)
+		} else {
+			s.dumpPrimitivePointerVal(v.Elem())
+		}
+	}
+}
+
+func (s *dumpState) dumpReusedPointerVal(value reflect.Value) {
+	if value.Kind() == reflect.Ptr && value.IsNil() {
+		return
+	}
+
+	v := deInterface(value)
+	kind := v.Kind()
+
+	switch kind {
+	case reflect.Invalid:
+		// Do nothing.  We should never get here since invalid has already
+		// been handled above.
+		s.w.Write([]byte("<invalid>"))
+
+	case reflect.Slice:
+		if v.IsNil() {
+			break
+		}
+		fallthrough
+
+	case reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			s.dumpReusedPointerVal(v.Index(i))
+		}
+
+	case reflect.Map:
+		keys := v.MapKeys()
+		sort.Sort(mapKeySorter{keys})
+		for _, key := range keys {
+			s.dumpReusedPointerVal(v.MapIndex(key))
+		}
+
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			s.dumpReusedPointerVal(v.Field(i))
+		}
+
+	case reflect.Ptr:
+		pointerName, isReused, isPrimitive, isFirstVisit := s.nameForPointer(v), s.isReusedPointer(v), s.isPrimitivePointer(v), s.visitPointerAndCheckIfFirstTime(v)
+		if isReused && !isPrimitive && isFirstVisit {
+			s.w.Write([]byte("var " + pointerName + " = &"))
+			s.dumpVal(v.Elem())
+			s.newline()
+		} else {
+			s.dumpReusedPointerVal(v.Elem())
+		}
+	}
+}
+
+func (s *dumpState) dumpVal(value reflect.Value) {
+	if value.Kind() == reflect.Ptr && value.IsNil() {
+		s.w.Write([]byte("nil"))
+		return
+	}
+
+	v := deInterface(value)
+	kind := v.Kind()
+	switch kind {
+	case reflect.Invalid:
+		// Do nothing.  We should never get here since invalid has already
+		// been handled above.
+		s.w.Write([]byte("<invalid>"))
+
+	case reflect.Bool:
+		printBool(s.w, v.Bool())
+
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
+		printInt(s.w, v.Int(), 10)
+
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
+		printUint(s.w, v.Uint(), 10)
+
+	case reflect.Float32:
+		printFloat(s.w, v.Float(), 32)
+
+	case reflect.Float64:
+		printFloat(s.w, v.Float(), 64)
+
+	case reflect.Complex64:
+		printComplex(s.w, v.Complex(), 32)
+
+	case reflect.Complex128:
+		printComplex(s.w, v.Complex(), 64)
+
+	case reflect.String:
+		s.w.Write([]byte(strconv.Quote(v.String())))
+
+	case reflect.Slice:
+		if v.IsNil() {
+			printNil(s.w)
+			break
+		}
+		fallthrough
+
+	case reflect.Array:
+		s.dumpSlice(v)
+
+	case reflect.Interface:
+		// The only time we should get here is for nil interfaces due to
+		// unpackValue calls.
+		if v.IsNil() {
+			printNil(s.w)
+		}
+
+	case reflect.Ptr:
+		pointerName, isPrimitive, isReused := s.nameForPointer(v), s.isPrimitivePointer(v), s.isReusedPointer(v)
+		if isPrimitive || isReused {
+			s.w.Write([]byte(pointerName))
+		} else {
+			s.w.Write([]byte("&"))
+			s.dumpVal(v.Elem())
+		}
+
+	case reflect.Map:
+		s.dumpMap(v)
+
+	case reflect.Struct:
+		s.dumpStruct(v)
+
+	default:
+		if v.CanInterface() {
+			fmt.Fprintf(s.w, "%v", v.Interface())
+		} else {
+			fmt.Fprintf(s.w, "%v", v.String())
+		}
+	}
+}
+
+// call to signal that the pointer is being visited, returns true if this is the
+// first visit to that pointer. Used to detect when to output the entire contents
+// behind a pointer (the first time), and when to just emit a name (all other times)
+func (s *dumpState) visitPointerAndCheckIfItIsTheFirstTime(ptr uintptr) bool {
+	for _, addr := range s.visitedPointers {
+		if addr == ptr {
+			return false
+		}
+	}
+	s.visitedPointers = append(s.visitedPointers, ptr)
+	return true
+}
+
+func (s *dumpState) nameForPointer(v reflect.Value) string {
+	if isPointerValue(v) {
+		ptr := v.Pointer()
+		for i, addr := range s.allPointers {
+			if ptr == addr {
+				return fmt.Sprintf("p%d", i)
+			}
+		}
+	}
+	return ""
+}
+
+func (s *dumpState) isPrimitivePointer(v reflect.Value) bool {
+	if isPointerValue(v) {
+		ptr := v.Pointer()
+		for _, addr := range s.primitivePointers {
+			if addr == ptr {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (s *dumpState) isReusedPointer(v reflect.Value) bool {
+	if isPointerValue(v) {
+		ptr := v.Pointer()
+		for _, addr := range s.reusedPointers {
+			if addr == ptr {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (s *dumpState) visitPointerAndCheckIfFirstTime(v reflect.Value) bool {
+	if isPointerValue(v) {
+		ptr := v.Pointer()
+		for _, addr := range s.visitedPointers {
+			if addr == ptr {
+				return false
+			}
+		}
+		s.visitedPointers = append(s.visitedPointers, ptr)
+	}
+
+	return true
+}
+
+// prepares a new state object for dumping the provided value
+func newDumpState(value interface{}, options *Options) *dumpState {
+	result := &dumpState{
+		config: options,
+	}
+
+	result.allPointers, result.reusedPointers, result.primitivePointers = GetPointers(reflect.ValueOf(value))
+
+	if options.HomePackage != "" {
+		result.homePackageRegexp = regexp.MustCompile(fmt.Sprintf("\\b%s\\.", options.HomePackage))
+	}
+
+	return result
+}
+
+// Dump a value to stdout
+func Dump(value interface{}) {
+	(&Config).Dump(value)
+}
+
+// Sdump dumps a value to a string
+func Sdump(value interface{}) string {
+	return (&Config).Sdump(value)
+}
+
+// Dump a value to stdout according to the options
+func (o Options) Dump(value interface{}) {
+
+		state := newDumpState(value, &o)
+		state.w = os.Stdout
+		state.dump(value)
+}
+
+// Sdump dumps a value to a string according to the options
+func (o Options) Sdump(value interface{}) string {
+	buf := new(bytes.Buffer)
+
+		state := newDumpState(value, &o)
+		state.w = buf
+		state.dump(value)
+
+	return buf.String()
+}
+
+type mapKeySorter struct {
+	keys []reflect.Value
+}
+
+func (s mapKeySorter) Len() int {
+	return len(s.keys)
+}
+
+func (s mapKeySorter) Swap(i, j int) {
+	s.keys[i], s.keys[j] = s.keys[j], s.keys[i]
+}
+
+func (s mapKeySorter) Less(i, j int) bool {
+	return fmt.Sprintf("%s", s.keys[i].Interface()) < fmt.Sprintf("%s", s.keys[j].Interface())
+}

--- a/dump/dump.go
+++ b/dump/dump.go
@@ -187,21 +187,35 @@ func (s *dumpState) printPrimitivePointer(value reflect.Value, pointerName strin
 	case reflect.Bool:
 		printBool(s.w, v.Bool())
 
-	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
-		printInt(s.w, v.Int(), 10)
+	case reflect.Int:
+		printInt(s.w, v.Int(), 10, "int")
+	case reflect.Int8:
+		printInt(s.w, v.Int(), 10, "int8")
+	case reflect.Int16:
+		printInt(s.w, v.Int(), 10, "int16")
+	case reflect.Int32:
+		printInt(s.w, v.Int(), 10, "int32")
+	case reflect.Int64:
+		printInt(s.w, v.Int(), 10, "int64")
 
-	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
-		printUint(s.w, v.Uint(), 10)
+	case reflect.Uint:
+		printUint(s.w, v.Uint(), 10, "uint")
+	case reflect.Uint8:
+		printUint(s.w, v.Uint(), 10, "uint8")
+	case reflect.Uint16:
+		printUint(s.w, v.Uint(), 10, "uint16")
+	case reflect.Uint32:
+		printUint(s.w, v.Uint(), 10, "uint32")
+	case reflect.Uint64:
+		printUint(s.w, v.Uint(), 10, "uint64")
 
 	case reflect.Float32:
-		printFloat(s.w, v.Float(), 32)
-
+		printFloat(s.w, v.Float(), 32, "float32")
 	case reflect.Float64:
-		printFloat(s.w, v.Float(), 64)
+		printFloat(s.w, v.Float(), 64, "float64")
 
 	case reflect.Complex64:
 		printComplex(s.w, v.Complex(), 32)
-
 	case reflect.Complex128:
 		printComplex(s.w, v.Complex(), 64)
 
@@ -326,21 +340,35 @@ func (s *dumpState) dumpVal(value reflect.Value) {
 	case reflect.Bool:
 		printBool(s.w, v.Bool())
 
-	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
-		printInt(s.w, v.Int(), 10)
+	case reflect.Int:
+		printInt(s.w, v.Int(), 10, "int")
+	case reflect.Int8:
+		printInt(s.w, v.Int(), 10, "int8")
+	case reflect.Int16:
+		printInt(s.w, v.Int(), 10, "int16")
+	case reflect.Int32:
+		printInt(s.w, v.Int(), 10, "int32")
+	case reflect.Int64:
+		printInt(s.w, v.Int(), 10, "int64")
 
-	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
-		printUint(s.w, v.Uint(), 10)
+	case reflect.Uint:
+		printUint(s.w, v.Uint(), 10, "uint")
+	case reflect.Uint8:
+		printUint(s.w, v.Uint(), 10, "uint8")
+	case reflect.Uint16:
+		printUint(s.w, v.Uint(), 10, "uint16")
+	case reflect.Uint32:
+		printUint(s.w, v.Uint(), 10, "uint32")
+	case reflect.Uint64:
+		printUint(s.w, v.Uint(), 10, "uint64")
 
 	case reflect.Float32:
-		printFloat(s.w, v.Float(), 32)
-
+		printFloat(s.w, v.Float(), 32, "float32")
 	case reflect.Float64:
-		printFloat(s.w, v.Float(), 64)
+		printFloat(s.w, v.Float(), 64, "float64")
 
 	case reflect.Complex64:
 		printComplex(s.w, v.Complex(), 32)
-
 	case reflect.Complex128:
 		printComplex(s.w, v.Complex(), 64)
 

--- a/dump/dump.go
+++ b/dump/dump.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
 package dump
 
 import (
@@ -30,19 +29,19 @@ import (
 
 var packageNameStripperRegexp = regexp.MustCompile("\\b[a-zA-Z_]+[a-zA-Z_0-9]+\\.")
 
-// Options represents configuration options for litter
+// Options represents configuration option
 type Options struct {
 	StripPackageNames bool
 	HidePrivateFields bool
 	HomePackage       string
-	VariableName 	  string
+	VariableName      string
 }
 
 // Config is the default config used when calling Dump
 var Config = Options{
 	StripPackageNames: false,
 	HidePrivateFields: true,
-	VariableName: "p0",
+	VariableName:      "Obj",
 }
 
 type dumpState struct {
@@ -159,8 +158,9 @@ func (s *dumpState) dumpMap(v reflect.Value) {
 
 func (s *dumpState) dump(value interface{}) {
 	if value == nil {
-		s.w.Write([]byte("var" + s.config.VariableName + "=" ))
+		s.w.Write([]byte("var " + s.config.VariableName + " = "))
 		printNil(s.w)
+		s.newline()
 		return
 	}
 	v := reflect.ValueOf(value)
@@ -170,11 +170,13 @@ func (s *dumpState) dump(value interface{}) {
 
 	s.dumpReusedPointerVal(v)
 
-	s.w.Write([]byte("var " + s.config.VariableName + " = " ))
-	if v.Kind() == reflect.Ptr && v.IsNil(){
-			printNil(s.w)
+	s.w.Write([]byte("var " + s.config.VariableName + " = "))
+	if v.Kind() == reflect.Ptr && v.IsNil() {
+		printNil(s.w)
+	} else {
+		s.dumpVal(v)
 	}
-	s.dumpVal(v)
+	s.newline()
 }
 
 func (s *dumpState) printPrimitivePointer(value reflect.Value, pointerName string) {
@@ -477,18 +479,18 @@ func Sdump(value interface{}) string {
 // Dump a value to stdout according to the options
 func (o Options) Dump(value interface{}) {
 
-		state := newDumpState(value, &o)
-		state.w = os.Stdout
-		state.dump(value)
+	state := newDumpState(value, &o)
+	state.w = os.Stdout
+	state.dump(value)
 }
 
 // Sdump dumps a value to a string according to the options
 func (o Options) Sdump(value interface{}) string {
 	buf := new(bytes.Buffer)
 
-		state := newDumpState(value, &o)
-		state.w = buf
-		state.dump(value)
+	state := newDumpState(value, &o)
+	state.w = buf
+	state.dump(value)
 
 	return buf.String()
 }

--- a/dump/dump_test.go
+++ b/dump/dump_test.go
@@ -1,0 +1,456 @@
+/*
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dump
+
+import (
+	"testing"
+)
+
+func TestSdumpPrimitives(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    func() interface{}
+		expected string
+	}{
+		{
+			"boolTrue",
+			func() interface{} {
+				return true
+			},
+			"var Obj = true\n",
+		},
+		{
+			"boolFalse",
+			func() interface{} {
+				return false
+			},
+			"var Obj = false\n",
+		},
+		{
+			"int",
+			func() interface{} {
+				return 10
+			},
+			"var Obj = 10\n",
+		},
+		{
+			"int8",
+			func() interface{} {
+				return int8(10)
+			},
+			"var Obj = 10\n",
+		},
+		{
+			"int16",
+			func() interface{} {
+				return int16(10)
+			},
+			"var Obj = 10\n",
+		},
+		{
+			"int32",
+			func() interface{} {
+				return int32(10)
+			},
+			"var Obj = 10\n",
+		},
+		{
+			"int64",
+			func() interface{} {
+				return int64(10)
+			},
+			"var Obj = 10\n",
+		},
+		{
+			"uint",
+			func() interface{} {
+				return uint(10)
+			},
+			"var Obj = 10\n",
+		},
+		{
+			"uint8",
+			func() interface{} {
+				return uint8(10)
+			},
+			"var Obj = 10\n",
+		},
+		{
+			"uint16",
+			func() interface{} {
+				return uint16(10)
+			},
+			"var Obj = 10\n",
+		},
+		{
+			"uint32",
+			func() interface{} {
+				return uint32(10)
+			},
+			"var Obj = 10\n",
+		},
+		{
+			"uint64",
+			func() interface{} {
+				return uint64(10)
+			},
+			"var Obj = 10\n",
+		},
+		{
+			"float32",
+			func() interface{} {
+				return float32(10.5)
+			},
+			"var Obj = 10.5\n",
+		},
+		{
+			"float64",
+			func() interface{} {
+				return float64(10.5)
+			},
+			"var Obj = 10.5\n",
+		},
+		{
+			"complex64",
+			func() interface{} {
+				return complex64(10 + 10.5i)
+			},
+			"var Obj = complex64(10+10.5i)\n",
+		},
+		{
+			"complex128",
+			func() interface{} {
+				return complex128(-1.2 - 0.5i)
+			},
+			"var Obj = complex128(-1.2-0.5i)\n",
+		},
+		{
+			"string",
+			func() interface{} {
+				return "hello world"
+			},
+			"var Obj = \"hello world\"\n",
+		},
+	}
+
+	for _, test := range testcases {
+		output := Sdump(test.input())
+		if test.expected != output {
+			t.Errorf("test case %s failed, expected : \n%#v\n, got : \n%#v", test.name, test.expected, output)
+		}
+	}
+}
+
+func TestSdumpPrimitivePointers(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    func() interface{}
+		expected string
+	}{
+		{
+			"booltruepointer",
+			func() interface{} {
+				var a = true
+				return &a
+			},
+			`var p0Var = true
+var p0 = &p0Var
+var Obj = p0
+`,
+		},
+		{
+			"boolfalsepointer",
+			func() interface{} {
+				var a = false
+				return &a
+			},
+			`var p0Var = false
+var p0 = &p0Var
+var Obj = p0
+`,
+		},
+		{
+			"intpointer",
+			func() interface{} {
+				var a = 10
+				return &a
+			},
+			`var p0Var = 10
+var p0 = &p0Var
+var Obj = p0
+`,
+		},
+		{
+			"int8pointer",
+			func() interface{} {
+				var a = int8(10)
+				return &a
+			},
+			`var p0Var = 10
+var p0 = &p0Var
+var Obj = p0
+`,
+		},
+		{
+			"int16pointer",
+			func() interface{} {
+				var a = int16(10)
+				return &a
+			},
+			`var p0Var = 10
+var p0 = &p0Var
+var Obj = p0
+`,
+		},
+		{
+			"int32pointer",
+			func() interface{} {
+				var a = int32(10)
+				return &a
+			},
+			`var p0Var = 10
+var p0 = &p0Var
+var Obj = p0
+`,
+		},
+		{
+			"int64pointer",
+			func() interface{} {
+				var a = int64(10)
+				return &a
+			},
+			`var p0Var = 10
+var p0 = &p0Var
+var Obj = p0
+`,
+		},
+		{
+			"uintpointer",
+			func() interface{} {
+				var a = uint(10)
+				return &a
+			},
+			`var p0Var = 10
+var p0 = &p0Var
+var Obj = p0
+`,
+		},
+		{
+			"uint8pointer",
+			func() interface{} {
+				var a = uint8(10)
+				return &a
+			},
+			`var p0Var = 10
+var p0 = &p0Var
+var Obj = p0
+`,
+		},
+		{
+			"uint16pointer",
+			func() interface{} {
+				var a = uint16(10)
+				return &a
+			},
+			`var p0Var = 10
+var p0 = &p0Var
+var Obj = p0
+`,
+		},
+		{
+			"uint32pointer",
+			func() interface{} {
+				var a = uint32(10)
+				return &a
+			},
+			`var p0Var = 10
+var p0 = &p0Var
+var Obj = p0
+`,
+		},
+		{
+			"uint64pointer",
+			func() interface{} {
+				var a = uint64(10)
+				return &a
+			},
+			`var p0Var = 10
+var p0 = &p0Var
+var Obj = p0
+`,
+		},
+		{
+			"float32pointer",
+			func() interface{} {
+				var a = float32(10.5)
+				return &a
+			},
+			`var p0Var = 10.5
+var p0 = &p0Var
+var Obj = p0
+`,
+		},
+		{
+			"float64pointer",
+			func() interface{} {
+				var a = float64(10.5)
+				return &a
+			},
+			`var p0Var = 10.5
+var p0 = &p0Var
+var Obj = p0
+`,
+		},
+		{
+			"complex64pointer",
+			func() interface{} {
+				var a = complex64(10 + 10.5i)
+				return &a
+			},
+			`var p0Var = complex64(10+10.5i)
+var p0 = &p0Var
+var Obj = p0
+`,
+		},
+		{
+			"complex128pointer",
+			func() interface{} {
+				var a = complex128(-1.2 - 0.5i)
+				return &a
+			},
+			`var p0Var = complex128(-1.2-0.5i)
+var p0 = &p0Var
+var Obj = p0
+`,
+		},
+		{
+			"stringpointer",
+			func() interface{} {
+				var a = "hello world"
+				return &a
+			},
+			`var p0Var = "hello world"
+var p0 = &p0Var
+var Obj = p0
+`,
+		},
+		{
+			"nilpointer",
+			func() interface{} {
+				return nil
+			},
+			`var Obj = nil
+`,
+		},
+		{
+			"stringnilpointer",
+			func() interface{} {
+				var a *string
+				return a
+			},
+			`var Obj = nil
+`,
+		},
+	}
+
+	for _, test := range testcases {
+		output := Sdump(test.input())
+		if test.expected != output {
+			t.Errorf("test case %s failed, expected : \n%#v\n, got : \n%#v", test.name, test.expected, output)
+		}
+	}
+}
+
+func TestSdumpReusedPointers(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    func() interface{}
+		expected string
+	}{
+		{
+			"reusedprimitivepointer",
+			func() interface{} {
+				var a = "hello world"
+				return &struct {
+					Foo *string
+					Bar *string
+				}{
+					Foo: &a,
+					Bar: &a,
+				}
+			},
+			`var p1Var = "hello world"
+var p1 = &p1Var
+var Obj = &struct { Foo *string; Bar *string }{
+	Foo: p1,
+	Bar: p1,
+}
+`,
+		},
+		{
+			"reusednilpointer",
+			func() interface{} {
+				var a *string
+				return &struct {
+					Foo *string
+					Bar *string
+				}{
+					Foo: a,
+					Bar: a,
+				}
+			},
+			`var Obj = &struct { Foo *string; Bar *string }{
+	Foo: nil,
+	Bar: nil,
+}
+`,
+		},
+		{
+			"reusedstructpointer",
+			func() interface{} {
+				type Zeo struct {
+					A string
+				}
+				var z = Zeo{
+					A: "hello world",
+				}
+				return &struct {
+					Foo *Zeo
+					Bar *Zeo
+				}{
+					Foo: &z,
+					Bar: &z,
+				}
+			},
+			`var p1 = &Zeo{
+	A: "hello world",
+}
+var Obj = &struct { Foo *Zeo; Bar *Zeo }{
+	Foo: p1,
+	Bar: p1,
+}
+`,
+		},
+	}
+	for _, test := range testcases {
+		Config.StripPackageNames = true
+		output := Sdump(test.input())
+		if test.expected != output {
+			t.Errorf("test case %s failed, expected : \n%#v\n, got : \n%#v", test.name, test.expected, output)
+		}
+	}
+}

--- a/dump/dump_test.go
+++ b/dump/dump_test.go
@@ -45,84 +45,84 @@ func TestSdumpPrimitives(t *testing.T) {
 			func() interface{} {
 				return 10
 			},
-			"var Obj = 10\n",
+			"var Obj = int(10)\n",
 		},
 		{
 			"int8",
 			func() interface{} {
 				return int8(10)
 			},
-			"var Obj = 10\n",
+			"var Obj = int8(10)\n",
 		},
 		{
 			"int16",
 			func() interface{} {
 				return int16(10)
 			},
-			"var Obj = 10\n",
+			"var Obj = int16(10)\n",
 		},
 		{
 			"int32",
 			func() interface{} {
 				return int32(10)
 			},
-			"var Obj = 10\n",
+			"var Obj = int32(10)\n",
 		},
 		{
 			"int64",
 			func() interface{} {
 				return int64(10)
 			},
-			"var Obj = 10\n",
+			"var Obj = int64(10)\n",
 		},
 		{
 			"uint",
 			func() interface{} {
 				return uint(10)
 			},
-			"var Obj = 10\n",
+			"var Obj = uint(10)\n",
 		},
 		{
 			"uint8",
 			func() interface{} {
 				return uint8(10)
 			},
-			"var Obj = 10\n",
+			"var Obj = uint8(10)\n",
 		},
 		{
 			"uint16",
 			func() interface{} {
 				return uint16(10)
 			},
-			"var Obj = 10\n",
+			"var Obj = uint16(10)\n",
 		},
 		{
 			"uint32",
 			func() interface{} {
 				return uint32(10)
 			},
-			"var Obj = 10\n",
+			"var Obj = uint32(10)\n",
 		},
 		{
 			"uint64",
 			func() interface{} {
 				return uint64(10)
 			},
-			"var Obj = 10\n",
+			"var Obj = uint64(10)\n",
 		},
 		{
 			"float32",
 			func() interface{} {
 				return float32(10.5)
 			},
-			"var Obj = 10.5\n",
+			"var Obj = float32(10.5)\n",
 		},
 		{
 			"float64",
 			func() interface{} {
 				return float64(10.5)
 			},
-			"var Obj = 10.5\n",
+			"var Obj = float64(10.5)\n",
 		},
 		{
 			"complex64",
@@ -189,7 +189,7 @@ var Obj = p0
 				var a = 10
 				return &a
 			},
-			`var p0Var = 10
+			`var p0Var = int(10)
 var p0 = &p0Var
 var Obj = p0
 `,
@@ -200,7 +200,7 @@ var Obj = p0
 				var a = int8(10)
 				return &a
 			},
-			`var p0Var = 10
+			`var p0Var = int8(10)
 var p0 = &p0Var
 var Obj = p0
 `,
@@ -211,7 +211,7 @@ var Obj = p0
 				var a = int16(10)
 				return &a
 			},
-			`var p0Var = 10
+			`var p0Var = int16(10)
 var p0 = &p0Var
 var Obj = p0
 `,
@@ -222,7 +222,7 @@ var Obj = p0
 				var a = int32(10)
 				return &a
 			},
-			`var p0Var = 10
+			`var p0Var = int32(10)
 var p0 = &p0Var
 var Obj = p0
 `,
@@ -233,7 +233,7 @@ var Obj = p0
 				var a = int64(10)
 				return &a
 			},
-			`var p0Var = 10
+			`var p0Var = int64(10)
 var p0 = &p0Var
 var Obj = p0
 `,
@@ -244,7 +244,7 @@ var Obj = p0
 				var a = uint(10)
 				return &a
 			},
-			`var p0Var = 10
+			`var p0Var = uint(10)
 var p0 = &p0Var
 var Obj = p0
 `,
@@ -255,7 +255,7 @@ var Obj = p0
 				var a = uint8(10)
 				return &a
 			},
-			`var p0Var = 10
+			`var p0Var = uint8(10)
 var p0 = &p0Var
 var Obj = p0
 `,
@@ -266,7 +266,7 @@ var Obj = p0
 				var a = uint16(10)
 				return &a
 			},
-			`var p0Var = 10
+			`var p0Var = uint16(10)
 var p0 = &p0Var
 var Obj = p0
 `,
@@ -277,7 +277,7 @@ var Obj = p0
 				var a = uint32(10)
 				return &a
 			},
-			`var p0Var = 10
+			`var p0Var = uint32(10)
 var p0 = &p0Var
 var Obj = p0
 `,
@@ -288,7 +288,7 @@ var Obj = p0
 				var a = uint64(10)
 				return &a
 			},
-			`var p0Var = 10
+			`var p0Var = uint64(10)
 var p0 = &p0Var
 var Obj = p0
 `,
@@ -299,7 +299,7 @@ var Obj = p0
 				var a = float32(10.5)
 				return &a
 			},
-			`var p0Var = 10.5
+			`var p0Var = float32(10.5)
 var p0 = &p0Var
 var Obj = p0
 `,
@@ -310,7 +310,7 @@ var Obj = p0
 				var a = float64(10.5)
 				return &a
 			},
-			`var p0Var = 10.5
+			`var p0Var = float64(10.5)
 var p0 = &p0Var
 var Obj = p0
 `,

--- a/dump/pointermap.go
+++ b/dump/pointermap.go
@@ -20,19 +20,19 @@ import "reflect"
 
 type pointerMap struct {
 	allpointers       []uintptr
-	reusedPointers 	  []uintptr
+	reusedPointers    []uintptr
 	primitivePointers []uintptr
 }
 
 // GetPointers: Given a structure, it will recursively map all pointers mentioned in the tree,
 // breaking circular references and provide list of:
 // * all pointers
-// * all pointers that was referenced at least twice
+// * all pointers that were referenced at least twice
 // * all pointers that point to primitive type
-func GetPointers(v reflect.Value) ([]uintptr, []uintptr, []uintptr){
+func GetPointers(v reflect.Value) ([]uintptr, []uintptr, []uintptr) {
 	pm := &pointerMap{
-		allpointers: []uintptr{},
-		reusedPointers: []uintptr{},
+		allpointers:       []uintptr{},
+		reusedPointers:    []uintptr{},
 		primitivePointers: []uintptr{},
 	}
 	pm.getAllAndReusedPointers(v)
@@ -147,6 +147,3 @@ func (pm *pointerMap) addPointer(ptr uintptr) bool {
 	pm.allpointers = append(pm.allpointers, ptr)
 	return false
 }
-
-
-

--- a/dump/pointermap.go
+++ b/dump/pointermap.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dump
+
+import "reflect"
+
+type pointerMap struct {
+	allpointers       []uintptr
+	reusedPointers 	  []uintptr
+	primitivePointers []uintptr
+}
+
+// GetPointers: Given a structure, it will recursively map all pointers mentioned in the tree,
+// breaking circular references and provide list of:
+// * all pointers
+// * all pointers that was referenced at least twice
+// * all pointers that point to primitive type
+func GetPointers(v reflect.Value) ([]uintptr, []uintptr, []uintptr){
+	pm := &pointerMap{
+		allpointers: []uintptr{},
+		reusedPointers: []uintptr{},
+		primitivePointers: []uintptr{},
+	}
+	pm.getAllAndReusedPointers(v)
+	pm.getPrimitivePointers(v)
+	return pm.allpointers, pm.reusedPointers, pm.primitivePointers
+}
+
+func (pm *pointerMap) getPrimitivePointers(v reflect.Value) {
+	if v.Kind() == reflect.Invalid {
+		return
+	}
+	// if v is a pointer pointing to a primitive value, register it as primitive pointer
+	if isPrimitivePointer(v) {
+		pm.addPrimitivePointer(v.Pointer())
+		return
+	}
+
+	// Now descend into any children of this value
+	switch v.Kind() {
+	case reflect.Slice, reflect.Array:
+		numEntries := v.Len()
+		for i := 0; i < numEntries; i++ {
+			pm.getPrimitivePointers(v.Index(i))
+		}
+
+	case reflect.Interface:
+		pm.getPrimitivePointers(v.Elem())
+
+	case reflect.Ptr:
+		pm.getPrimitivePointers(v.Elem())
+
+	case reflect.Map:
+		for _, key := range v.MapKeys() {
+			pm.getPrimitivePointers(v.MapIndex(key))
+		}
+
+	case reflect.Struct:
+		numFields := v.NumField()
+		for i := 0; i < numFields; i++ {
+			pm.getPrimitivePointers(v.Field(i))
+		}
+	}
+}
+
+// Recursively consider v and each of its children, updating pointer information
+func (pm *pointerMap) getAllAndReusedPointers(v reflect.Value) {
+	if v.Kind() == reflect.Invalid {
+		return
+	}
+	if isPointerValue(v) && v.Pointer() != 0 { // pointer is 0 for unexported fields
+		reused := pm.addPointer(v.Pointer())
+		if reused {
+			// No use descending inside this value, since it have been seen before and all its descendants
+			// have been considered
+			return
+		}
+	}
+
+	// Now descend into any children of this value
+	switch v.Kind() {
+	case reflect.Slice, reflect.Array:
+		numEntries := v.Len()
+		for i := 0; i < numEntries; i++ {
+			pm.getAllAndReusedPointers(v.Index(i))
+		}
+
+	case reflect.Interface:
+		pm.getAllAndReusedPointers(v.Elem())
+
+	case reflect.Ptr:
+		pm.getAllAndReusedPointers(v.Elem())
+
+	case reflect.Map:
+		for _, key := range v.MapKeys() {
+			pm.getAllAndReusedPointers(v.MapIndex(key))
+		}
+
+	case reflect.Struct:
+		numFields := v.NumField()
+		for i := 0; i < numFields; i++ {
+			pm.getAllAndReusedPointers(v.Field(i))
+		}
+	}
+}
+
+func (pm *pointerMap) addPrimitivePointer(ptr uintptr) {
+	for _, have := range pm.primitivePointers {
+		if ptr == have {
+			return
+		}
+	}
+	pm.primitivePointers = append(pm.primitivePointers, ptr)
+}
+
+// addPointer to the pointerMap, update reusedPointers. Returns true if pointer was reused
+func (pm *pointerMap) addPointer(ptr uintptr) bool {
+	// Is this already known to be reused?
+	for _, have := range pm.reusedPointers {
+		if ptr == have {
+			return true
+		}
+	}
+	// Have we seen it once before?
+	for _, seen := range pm.allpointers {
+		if ptr == seen {
+			// Add it to the register of pointers we have seen more than once
+			pm.reusedPointers = append(pm.reusedPointers, ptr)
+			return true
+		}
+	}
+	// This pointer was new to us
+	pm.allpointers = append(pm.allpointers, ptr)
+	return false
+}
+
+
+

--- a/dump/utils.go
+++ b/dump/utils.go
@@ -18,16 +18,12 @@ package dump
 
 import (
 	"io"
-	"strconv"
 	"reflect"
+	"strconv"
 )
 
 func printBool(w io.Writer, value bool) {
-	if value {
-		w.Write([]byte("true"))
-		return
-	}
-	w.Write([]byte("false"))
+	w.Write([]byte(strconv.FormatBool(value)))
 }
 
 func printInt(w io.Writer, val int64, base int) {
@@ -60,7 +56,6 @@ func printNil(w io.Writer) {
 	w.Write([]byte("nil"))
 }
 
-
 // deInterface returns values inside of non-nil interfaces when possible.
 // This is useful for data types like structs, arrays, slices, and maps which
 // can contain varying types packed inside an interface.
@@ -91,7 +86,7 @@ func isPrimitiveValue(v reflect.Value) bool {
 	case reflect.Bool, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Float32,
 		reflect.Float64, reflect.Complex64, reflect.Complex128, reflect.String:
-			return  true
+		return true
 	}
 	return false
 }

--- a/dump/utils.go
+++ b/dump/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package dump
 
 import (
+	"fmt"
 	"io"
 	"reflect"
 	"strconv"
@@ -26,21 +27,21 @@ func printBool(w io.Writer, value bool) {
 	w.Write([]byte(strconv.FormatBool(value)))
 }
 
-func printInt(w io.Writer, val int64, base int) {
-	w.Write([]byte(strconv.FormatInt(val, base)))
+func printInt(w io.Writer, val int64, base int, intType string) {
+	w.Write([]byte(fmt.Sprintf("%s(%s)", intType, strconv.FormatInt(val, base))))
 }
 
-func printUint(w io.Writer, val uint64, base int) {
-	w.Write([]byte(strconv.FormatUint(val, base)))
+func printUint(w io.Writer, val uint64, base int, uintType string) {
+	w.Write([]byte(fmt.Sprintf("%s(%s)", uintType, strconv.FormatUint(val, base))))
 }
 
-func printFloat(w io.Writer, val float64, precision int) {
-	w.Write([]byte(strconv.FormatFloat(val, 'g', -1, precision)))
+func printFloat(w io.Writer, val float64, precision int, floatType string) {
+	w.Write([]byte(fmt.Sprintf("%s(%s)", floatType, strconv.FormatFloat(val, 'g', -1, precision))))
 }
 
 func printComplex(w io.Writer, c complex128, floatPrecision int) {
 	w.Write([]byte("complex"))
-	printInt(w, int64(floatPrecision*2), 10)
+	w.Write([]byte(fmt.Sprintf("%d", floatPrecision*2)))
 	r := real(c)
 	w.Write([]byte("("))
 	w.Write([]byte(strconv.FormatFloat(r, 'g', -1, floatPrecision)))

--- a/dump/utils.go
+++ b/dump/utils.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dump
+
+import (
+	"io"
+	"strconv"
+	"reflect"
+)
+
+func printBool(w io.Writer, value bool) {
+	if value {
+		w.Write([]byte("true"))
+		return
+	}
+	w.Write([]byte("false"))
+}
+
+func printInt(w io.Writer, val int64, base int) {
+	w.Write([]byte(strconv.FormatInt(val, base)))
+}
+
+func printUint(w io.Writer, val uint64, base int) {
+	w.Write([]byte(strconv.FormatUint(val, base)))
+}
+
+func printFloat(w io.Writer, val float64, precision int) {
+	w.Write([]byte(strconv.FormatFloat(val, 'g', -1, precision)))
+}
+
+func printComplex(w io.Writer, c complex128, floatPrecision int) {
+	w.Write([]byte("complex"))
+	printInt(w, int64(floatPrecision*2), 10)
+	r := real(c)
+	w.Write([]byte("("))
+	w.Write([]byte(strconv.FormatFloat(r, 'g', -1, floatPrecision)))
+	i := imag(c)
+	if i >= 0 {
+		w.Write([]byte("+"))
+	}
+	w.Write([]byte(strconv.FormatFloat(i, 'g', -1, floatPrecision)))
+	w.Write([]byte("i)"))
+}
+
+func printNil(w io.Writer) {
+	w.Write([]byte("nil"))
+}
+
+
+// deInterface returns values inside of non-nil interfaces when possible.
+// This is useful for data types like structs, arrays, slices, and maps which
+// can contain varying types packed inside an interface.
+func deInterface(v reflect.Value) reflect.Value {
+	if v.Kind() == reflect.Interface && !v.IsNil() {
+		v = v.Elem()
+	}
+	return v
+}
+
+func isPointerValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Slice, reflect.UnsafePointer:
+		return true
+	}
+	return false
+}
+
+func isPrimitivePointer(v reflect.Value) bool {
+	if v.Kind() == reflect.Ptr && isPrimitiveValue(v.Elem()) {
+		return true
+	}
+	return false
+}
+
+func isPrimitiveValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Bool, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Float32,
+		reflect.Float64, reflect.Complex64, reflect.Complex128, reflect.String:
+			return  true
+	}
+	return false
+}

--- a/interpreter.go
+++ b/interpreter.go
@@ -812,10 +812,7 @@ func evaluateStd(i *interpreter) (value, error) {
 	)
 	evalLoc := ast.MakeLocationRangeMessage("During evaluation of std")
 	evalTrace := &TraceElement{loc: &evalLoc}
-	node, err := snippetToAST("<std>", getStdCode())
-	if err != nil {
-		return nil, err
-	}
+	node := ast.StdAst
 	return i.EvalInCleanEnv(evalTrace, &beforeStdEnv, node, false)
 }
 

--- a/vm.go
+++ b/vm.go
@@ -142,6 +142,10 @@ func snippetToAST(filename string, snippet string) (ast.Node, error) {
 	return node, nil
 }
 
+func SnippetToAST(filename string, snippet string) (ast.Node, error) {
+	return snippetToAST(filename, snippet)
+}
+
 func Version() string {
 	return "v0.9.5"
 }


### PR DESCRIPTION
utter(github.com/kortschak/utter) is powerful to dump go data structure as go source code.

To dump ast and make the source code usable in other package, we need make "loc" and "freeVariables" in NodeBase struct as public. Otherwise, the dumped source code can only be used in "ast" package.

This pr is just send out for further comment and feedback and demonstrates that pre-parse stdlib is practicable. If this way looks good, I will close this and send several elaborate PRs:
* make "loc" and "freeVariables" in NodeBase struct as public
* add a "Dump()"  function in "ast" package, which leveraging utter(github.com/kortschak/utter)
* add a dump command line tool which can read a jsonnet file and dump it's ast. The dump tool will call the "Dump()"  function in "ast" package
* using the dump tool to generate go source code for stdlib, and embed it into vm.