### PR TITLE
Eliminate duplication in builtin names

### DIFF
--- a/testdata/builtinObjectFieldsEx_bad.golden
+++ b/testdata/builtinObjectFieldsEx_bad.golden
@@ -1,6 +1,6 @@
 RUNTIME ERROR: Unexpected type number, expected object
 -------------------------------------------------
-	<builtin>	builtin function <objectFields>
+	<builtin>	builtin function <objectFieldsEx>
 
 -------------------------------------------------
 	During evaluation	

--- a/testdata/builtinObjectFieldsEx_bad2.golden
+++ b/testdata/builtinObjectFieldsEx_bad2.golden
@@ -1,6 +1,6 @@
 RUNTIME ERROR: Unexpected type string, expected boolean
 -------------------------------------------------
-	<builtin>	builtin function <objectFields>
+	<builtin>	builtin function <objectFieldsEx>
 
 -------------------------------------------------
 	During evaluation	


### PR DESCRIPTION
Actually there was one (objectFieldEx) that was inconsistent, i.e.
it was available by a different name from what appeared in the stack
trace. This is now fixed.