### PR TITLE
Represent types as Go objects, not strings (give them pointer identity)

### DIFF
--- a/builtins.go
+++ b/builtins.go
@@ -359,7 +359,7 @@ func primitiveEquals(e *evaluator, xp potentialValue, yp potentialValue) (value,
 	if err != nil {
 		return nil, err
 	}
-	if x.typename() != y.typename() { // TODO(sbarzowski) ugh, string comparison
+	if x.getType() != y.getType() {
 		return makeValueBoolean(false), nil
 	}
 	switch left := x.(type) {
@@ -387,7 +387,7 @@ func primitiveEquals(e *evaluator, xp potentialValue, yp potentialValue) (value,
 		return nil, e.Error("Cannot test equality of functions")
 	default:
 		return nil, e.Error(
-			"primitiveEquals operates on primitive types, got " + x.typename(),
+			"primitiveEquals operates on primitive types, got " + x.getType().name,
 		)
 	}
 }
@@ -397,7 +397,7 @@ func builtinType(e *evaluator, xp potentialValue) (value, error) {
 	if err != nil {
 		return nil, err
 	}
-	return makeValueString(x.typename()), nil
+	return makeValueString(x.getType().name), nil
 }
 
 func builtinMd5(e *evaluator, xp potentialValue) (value, error) {

--- a/evaluator.go
+++ b/evaluator.go
@@ -49,13 +49,13 @@ func (e *evaluator) Error(s string) error {
 
 func (e *evaluator) typeErrorSpecific(bad value, good value) error {
 	return e.Error(
-		fmt.Sprintf("Unexpected type %v, expected %v", bad.typename(), good.typename()),
+		fmt.Sprintf("Unexpected type %v, expected %v", bad.getType().name, good.getType().name),
 	)
 }
 
 func (e *evaluator) typeErrorGeneral(bad value) error {
 	return e.Error(
-		fmt.Sprintf("Unexpected type %v", bad.typename()),
+		fmt.Sprintf("Unexpected type %v", bad.getType().name),
 	)
 }
 

--- a/interpreter.go
+++ b/interpreter.go
@@ -189,8 +189,6 @@ func makeCallStack(limit int) callStack {
 	}
 }
 
-// TODO(dcunnin): Add multi output.
-
 // Keeps current execution context and evaluates things
 type interpreter struct {
 	// Current stack. It is used for:
@@ -321,7 +319,7 @@ func (i *interpreter) evaluate(a ast.Node) (value, error) {
 				// Omitted field.
 				continue
 			default:
-				return nil, e.Error(fmt.Sprintf("Field name must be string, got %v", fieldNameValue.typename()))
+				return nil, e.Error(fmt.Sprintf("Field name must be string, got %v", fieldNameValue.getType().name))
 			}
 
 			if _, ok := fields[fieldName]; ok {

--- a/value.go
+++ b/value.go
@@ -28,9 +28,20 @@ import (
 type value interface {
 	aValue()
 
-	// TODO(sbarzowski) consider representing each type as golang object
-	typename() string
+	getType() *valueType
 }
+
+type valueType struct {
+	name string
+}
+
+var stringType = &valueType{"string"}
+var numberType = &valueType{"number"}
+var functionType = &valueType{"function"}
+var objectType = &valueType{"object"}
+var booleanType = &valueType{"boolean"}
+var nullType = &valueType{"null"}
+var arrayType = &valueType{"array"}
 
 // potentialValue is something that may be evaluated to a concrete value.
 // The result of the evaluation may *NOT* depend on the current state
@@ -124,8 +135,8 @@ func makeValueString(v string) *valueString {
 	return &valueString{value: []rune(v)}
 }
 
-func (*valueString) typename() string {
-	return "string"
+func (*valueString) getType() *valueType {
+	return stringType
 }
 
 type valueBoolean struct {
@@ -133,8 +144,8 @@ type valueBoolean struct {
 	value bool
 }
 
-func (*valueBoolean) typename() string {
-	return "boolean"
+func (*valueBoolean) getType() *valueType {
+	return booleanType
 }
 
 func makeValueBoolean(v bool) *valueBoolean {
@@ -150,8 +161,8 @@ type valueNumber struct {
 	value float64
 }
 
-func (*valueNumber) typename() string {
-	return "number"
+func (*valueNumber) getType() *valueType {
+	return numberType
 }
 
 func makeValueNumber(v float64) *valueNumber {
@@ -176,8 +187,8 @@ func makeValueNull() *valueNull {
 	return &nullValue
 }
 
-func (*valueNull) typename() string {
-	return "null"
+func (*valueNull) getType() *valueType {
+	return nullType
 }
 
 // ast.Array
@@ -220,8 +231,8 @@ func concatArrays(a, b *valueArray) *valueArray {
 	return &valueArray{elements: result}
 }
 
-func (*valueArray) typename() string {
-	return "array"
+func (*valueArray) getType() *valueType {
+	return arrayType
 }
 
 // ast.Function
@@ -256,8 +267,8 @@ func checkArguments(e *evaluator, args callArguments, params ast.Identifiers) er
 	return nil
 }
 
-func (f *valueFunction) typename() string {
-	return "function"
+func (f *valueFunction) getType() *valueType {
+	return functionType
 }
 
 type callArguments struct {
@@ -344,8 +355,8 @@ type valueObjectBase struct {
 	assertionError error
 }
 
-func (*valueObjectBase) typename() string {
-	return "object"
+func (*valueObjectBase) getType() *valueType {
+	return objectType
 }
 
 func (obj *valueObjectBase) assertionsChecked() bool {


### PR DESCRIPTION
Faster comparisons and IMO cleaner feeling overall.
It doesn't affect behaviour in any way.