### PR TITLE
Rename `jsonnet.nativeFunction` -> `jsonnet.NativeFunction`

### DIFF
--- a/interpreter.go
+++ b/interpreter.go
@@ -217,7 +217,7 @@ type interpreter struct {
 	extVars map[string]potentialValue
 
 	// Native functions
-	nativeFuncs map[string]*nativeFunction
+	nativeFuncs map[string]*NativeFunction
 
 	// A part of std object common to all files
 	baseStd valueObject
@@ -847,7 +847,7 @@ func buildObject(hide ast.ObjectFieldHide, fields map[string]value) valueObject 
 	return makeValueSimpleObject(bindingFrame{}, fieldMap, nil)
 }
 
-func buildInterpreter(ext vmExtMap, nativeFuncs map[string]*nativeFunction, maxStack int, importer Importer) (*interpreter, error) {
+func buildInterpreter(ext vmExtMap, nativeFuncs map[string]*NativeFunction, maxStack int, importer Importer) (*interpreter, error) {
 	i := interpreter{
 		stack:       makeCallStack(maxStack),
 		importCache: MakeImportCache(importer),
@@ -879,7 +879,7 @@ func makeInitialEnv(filename string, baseStd valueObject) environment {
 }
 
 // TODO(sbarzowski) this function takes far too many arguments - build interpreter in vm instead
-func evaluate(node ast.Node, ext vmExtMap, tla vmExtMap, nativeFuncs map[string]*nativeFunction, maxStack int, importer Importer) (string, error) {
+func evaluate(node ast.Node, ext vmExtMap, tla vmExtMap, nativeFuncs map[string]*NativeFunction, maxStack int, importer Importer) (string, error) {
 	i, err := buildInterpreter(ext, nativeFuncs, maxStack, importer)
 	if err != nil {
 		return "", err

--- a/main_test.go
+++ b/main_test.go
@@ -102,7 +102,7 @@ func TestMain(t *testing.T) {
 				vm.ExtCode(name, value)
 			}
 
-			vm.NativeFunction(&nativeFunction{
+			vm.NativeFunction(&NativeFunction{
 				name:   "jsonToString",
 				params: ast.Identifiers{"x"},
 				f: func(x []interface{}) (interface{}, error) {

--- a/thunks.go
+++ b/thunks.go
@@ -287,13 +287,13 @@ func makeClosure(env environment, function *ast.Function) *closure {
 	}
 }
 
-type nativeFunction struct {
+type NativeFunction struct {
 	f      func([]interface{}) (interface{}, error)
 	params ast.Identifiers
 	name   string
 }
 
-func (native *nativeFunction) EvalCall(arguments callArguments, e *evaluator) (value, error) {
+func (native *NativeFunction) EvalCall(arguments callArguments, e *evaluator) (value, error) {
 	flatArgs := flattenArgs(arguments, native.Parameters())
 	nativeArgs := make([]interface{}, 0, len(flatArgs))
 	for _, arg := range flatArgs {
@@ -314,7 +314,7 @@ func (native *nativeFunction) EvalCall(arguments callArguments, e *evaluator) (v
 	return jsonToValue(e, resultJSON)
 }
 
-func (native *nativeFunction) Parameters() Parameters {
+func (native *NativeFunction) Parameters() Parameters {
 	return Parameters{required: native.params}
 }
 

--- a/vm.go
+++ b/vm.go
@@ -35,7 +35,7 @@ type VM struct {
 	MaxTrace    int // The number of lines of stack trace to display (0 for all of them).
 	ext         vmExtMap
 	tla         vmExtMap
-	nativeFuncs map[string]*nativeFunction
+	nativeFuncs map[string]*NativeFunction
 	importer    Importer
 	ef          ErrorFormatter
 }
@@ -57,7 +57,7 @@ func MakeVM() *VM {
 		MaxStack:    500,
 		ext:         make(vmExtMap),
 		tla:         make(vmExtMap),
-		nativeFuncs: make(map[string]*nativeFunction),
+		nativeFuncs: make(map[string]*NativeFunction),
 		ef:          ErrorFormatter{pretty: true, colorful: true, MaxStackTraceSize: 20},
 		importer:    &FileImporter{},
 	}
@@ -106,7 +106,7 @@ func (vm *VM) evaluateSnippet(filename string, snippet string) (output string, e
 }
 
 // NativeFunction registers a native function
-func (vm *VM) NativeFunction(f *nativeFunction) {
+func (vm *VM) NativeFunction(f *NativeFunction) {
 	vm.nativeFuncs[f.name] = f
 }
 


### PR DESCRIPTION
NOTE: I have not yet tested this patch, as I cannot seem to run the `tests.sh` file. I am putting it up anyway just to make sure that I'm on at least the right track.

Currently, `jsonnet.VM#NativeFunction` takes a single argument of type
`jsonnet.nativeFunction`. This is ok for internal use, but because this
type is private to the `jsonnet` package, it is not possible for a
third party to call this function (since it can't instantiate the type).

This commit makes this type public to remedy this problem.