### PR TITLE
Expose MemoryImporter data

### DIFF
--- a/imports.go
+++ b/imports.go
@@ -144,11 +144,11 @@ func (importer *FileImporter) Import(dir, importedPath string) *ImportedData {
 }
 
 type MemoryImporter struct {
-	data map[string]string
+	Data map[string]string
 }
 
 func (importer *MemoryImporter) Import(dir, importedPath string) *ImportedData {
-	if content, ok := importer.data[importedPath]; ok {
+	if content, ok := importer.Data[importedPath]; ok {
 		return &ImportedData{content: content, foundHere: importedPath}
 	}
 	return &ImportedData{err: fmt.Errorf("Import not available %v", importedPath)}


### PR DESCRIPTION
MemoryImporter is convenient to use in an embedded VM setting when an import needs to be passed to a script.

Signed-off-by: Kuat Yessenov <kuat@google.com>