### PR TITLE
jsonnet: Fix --output-file command line option

### DIFF
--- a/jsonnet/cmd.go
+++ b/jsonnet/cmd.go
@@ -214,7 +214,7 @@ func processArgs(givenArgs []string, config *config, vm *jsonnet.VM) (processArg
 			return processArgsStatusSuccess, nil
 		} else if arg == "-e" || arg == "--exec" {
 			config.filenameIsCode = true
-		} else if arg == "-o" || arg == "--exec" {
+		} else if arg == "-o" || arg == "--output-file" {
 			outputFile := nextArg(&i, args)
 			if len(outputFile) == 0 {
 				return processArgsStatusFailure, fmt.Errorf("ERROR: -o argument was empty string")


### PR DESCRIPTION
The long option --output-file was not working, due to what looks like a
cut and paste error, leaving --exec as the string to test for.