### PR TITLE
Remove unsued dependencies

### DIFF
--- a/_gen.go
+++ b/_gen.go
@@ -1,7 +1,0 @@
-package main
-
-import (
-	_ "github.com/clipperhouse/set"
-	_ "github.com/clipperhouse/slice"
-	_ "github.com/clipperhouse/stringer"
-)

--- a/jsonnet/cmd.go
+++ b/jsonnet/cmd.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/google/go-jsonnet"
 )
 
@@ -185,12 +186,13 @@ func getVarFile(s string) (string, string, error) {
 }
 
 type processArgsStatus = int
+
 const (
-	processArgsStatusContinue = iota
+	processArgsStatusContinue     = iota
 	processArgsStatusSuccessUsage = iota
 	processArgsStatusFailureUsage = iota
-	processArgsStatusSuccess = iota
-	processArgsStatusFailure = iota
+	processArgsStatusSuccess      = iota
+	processArgsStatusFailure      = iota
 )
 
 func processArgs(givenArgs []string, config *config, vm *jsonnet.VM) (processArgsStatus, error) {
@@ -304,7 +306,7 @@ func processArgs(givenArgs []string, config *config, vm *jsonnet.VM) (processArg
 				if l < 0 {
 					return processArgsStatusFailure, fmt.Errorf("ERROR: Invalid --max-trace value: %d", l)
 				}
-				vm.ErrorFormatter.MaxStackTraceSize = l
+				vm.ErrorFormatter.SetMaxStackTraceSize(l)
 			} else if arg == "-m" || arg == "--multi" {
 				config.evalMulti = true
 				outputDir := nextArg(&i, args)
@@ -501,6 +503,7 @@ func main() {
 	}
 
 	vm := jsonnet.MakeVM()
+	vm.ErrorFormatter.SetColorFormatter(color.New(color.FgRed).Fprintf)
 
 	config := makeConfig()
 	status, err := processArgs(os.Args[1:], &config, vm)

--- a/main_test.go
+++ b/main_test.go
@@ -90,7 +90,7 @@ func TestMain(t *testing.T) {
 		}
 		mainTests = append(mainTests, mainTest{name: name, input: input, golden: golden, meta: &meta})
 	}
-	errFormatter := ErrorFormatter{pretty: true, MaxStackTraceSize: 9}
+	errFormatter := termErrorFormatter{pretty: true, maxStackTraceSize: 9}
 	for _, test := range mainTests {
 		t.Run(test.name, func(t *testing.T) {
 			vm := MakeVM()
@@ -127,7 +127,7 @@ func TestMain(t *testing.T) {
 			if err != nil {
 				// TODO(sbarzowski) perhaps somehow mark that we are processing
 				// an error. But for now we can treat them the same.
-				output = errFormatter.format(err)
+				output = errFormatter.Format(err)
 				output += "\n"
 			} else {
 				output = rawOutput.(string)
@@ -226,9 +226,9 @@ var minimalErrorTests = []errorFormattingTest{
 }
 
 func TestMinimalError(t *testing.T) {
-	formatter := ErrorFormatter{MaxStackTraceSize: 20}
+	formatter := termErrorFormatter{maxStackTraceSize: 20}
 	genericTestErrorMessage(t, minimalErrorTests, func(r RuntimeError) string {
-		return formatter.format(r)
+		return formatter.Format(r)
 	})
 }
 

--- a/vm.go
+++ b/vm.go
@@ -58,7 +58,7 @@ func MakeVM() *VM {
 		ext:            make(vmExtMap),
 		tla:            make(vmExtMap),
 		nativeFuncs:    make(map[string]*NativeFunction),
-		ErrorFormatter: ErrorFormatter{pretty: false, colorful: false, MaxStackTraceSize: 20},
+		ErrorFormatter: &termErrorFormatter{pretty: false, maxStackTraceSize: 20},
 		importer:       &FileImporter{},
 	}
 }
@@ -132,7 +132,7 @@ func (vm *VM) NativeFunction(f *NativeFunction) {
 func (vm *VM) EvaluateSnippet(filename string, snippet string) (json string, formattedErr error) {
 	output, err := vm.evaluateSnippet(filename, snippet, evalKindRegular)
 	if err != nil {
-		return "", errors.New(vm.ErrorFormatter.format(err))
+		return "", errors.New(vm.ErrorFormatter.Format(err))
 	}
 	json = output.(string)
 	return
@@ -145,7 +145,7 @@ func (vm *VM) EvaluateSnippet(filename string, snippet string) (json string, for
 func (vm *VM) EvaluateSnippetStream(filename string, snippet string) (docs []string, formattedErr error) {
 	output, err := vm.evaluateSnippet(filename, snippet, evalKindStream)
 	if err != nil {
-		return nil, errors.New(vm.ErrorFormatter.format(err))
+		return nil, errors.New(vm.ErrorFormatter.Format(err))
 	}
 	docs = output.([]string)
 	return
@@ -158,7 +158,7 @@ func (vm *VM) EvaluateSnippetStream(filename string, snippet string) (docs []str
 func (vm *VM) EvaluateSnippetMulti(filename string, snippet string) (files map[string]string, formattedErr error) {
 	output, err := vm.evaluateSnippet(filename, snippet, evalKindMulti)
 	if err != nil {
-		return nil, errors.New(vm.ErrorFormatter.format(err))
+		return nil, errors.New(vm.ErrorFormatter.Format(err))
 	}
 	files = output.(map[string]string)
 	return


### PR DESCRIPTION
The imports in "_gen.go" were not used, compiled, or
apparently useful so remove.

The color field in the ErrorFormatter was never set
to true and never used. This brought in many unused
dependencies including x/sys/unix that aren't ever
used.

While these aren't huge issues, they add significant
un-needed burden when reviewing imports. I have to
remove them before using the package.

Fixes google/go-jsonnet#131