### PR TITLE
Add test case for native function returning error

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -19,6 +19,7 @@ package jsonnet
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"flag"
 	"io/ioutil"
 	"path/filepath"
@@ -81,6 +82,14 @@ var jsonToString = &NativeFunction{
 	},
 }
 
+var nativeError = &NativeFunction{
+	Name: "nativeError",
+	Params: ast.Identifiers{},
+	Func: func(x []interface{}) (interface{}, error) {
+		return nil, errors.New("Native function error")
+	},
+}
+
 type jsonnetInput struct {
 	name    string
 	input   []byte
@@ -106,6 +115,7 @@ func runJsonnet(i jsonnetInput) jsonnetResult {
 	}
 
 	vm.NativeFunction(jsonToString)
+	vm.NativeFunction(nativeError)
 
 	var output string
 

--- a/testdata/native_error.golden
+++ b/testdata/native_error.golden
@@ -1,0 +1,10 @@
+RUNTIME ERROR: Native function error
+-------------------------------------------------
+	testdata/native_error:1:1-28	$
+
+std.native("nativeError")()
+
+-------------------------------------------------
+	During evaluation	
+
+

--- a/testdata/native_error.jsonnet
+++ b/testdata/native_error.jsonnet
@@ -1,0 +1,1 @@
+std.native("nativeError")()


### PR DESCRIPTION
A native function returning an error should be reported as a runtime
error, with a stack trace.