### PR TITLE
Oldest version known to work = Go 1.8, closes #177

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 sudo: false
 go:
   - 1.x
+  - 1.8.x
   - tip
 before_install:
   - go get github.com/axw/gocov/gocov

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ feature complete but is not as heavily exercised as the [Jsonnet C++
 implementation](https://github.com/google/jsonnet).  Please try it out and give
 feedback.
 
-This code is known to work on Go 1.6 and above.
+This code is known to work on Go 1.8 and above. We recommend always using the newest stable release of Go.
 
 ## Build instructions
 

--- a/builtins.go
+++ b/builtins.go
@@ -549,7 +549,14 @@ var builtinAsin = liftNumeric(math.Asin)
 var builtinAcos = liftNumeric(math.Acos)
 var builtinAtan = liftNumeric(math.Atan)
 var builtinLog = liftNumeric(math.Log)
-var builtinExp = liftNumeric(math.Exp)
+var builtinExp = liftNumeric(func(f float64) float64 {
+	res := math.Exp(f)
+	if res == 0 && f > 0 {
+		return math.Inf(1)
+	} else {
+		return res
+	}
+})
 var builtinMantissa = liftNumeric(func(f float64) float64 {
 	mantissa, _ := math.Frexp(f)
 	return mantissa


### PR DESCRIPTION
It seems like it was broken on older compilers
since pregenerated stdlib AST.

Add go 1.8.x to travis, so that we have a chance
of catching when our "known to work" no longer holds.