### PR TITLE
Fix processing the same file many times

### DIFF
--- a/imports.go
+++ b/imports.go
@@ -48,7 +48,7 @@ type importCacheKey struct {
 	importedPath string
 }
 
-type importCacheMap map[importCacheKey]ImportCacheValue
+type importCacheMap map[importCacheKey]*ImportCacheValue
 
 type ImportCache struct {
 	cache    importCacheMap
@@ -61,15 +61,15 @@ func MakeImportCache(importer Importer) *ImportCache {
 
 func (cache *ImportCache) importData(key importCacheKey) *ImportCacheValue {
 	if cached, ok := cache.cache[key]; ok {
-		return &cached
+		return cached
 	}
 	data, err := cache.importer.Import(key.dir, key.importedPath)
-	cached := ImportCacheValue{
+	cached := &ImportCacheValue{
 		data: data,
-		err: err,
+		err:  err,
 	}
 	cache.cache[key] = cached
-	return &cached
+	return cached
 }
 
 func (cache *ImportCache) ImportString(codeDir, importedPath string, e *evaluator) (*valueString, error) {


### PR DESCRIPTION
There was a trivial bug, which disabled caching
of parsed, desugared and analyzed code. So imports
were only cached on data level, not on executable
ast level.

This change will likely result in ~10x speedup
for some users.