### PR TITLE
Convert --tla/ext-*-file to imports

### DIFF
--- a/jsonnet/cmd.go
+++ b/jsonnet/cmd.go
@@ -173,17 +173,13 @@ func getVarVal(s string) (string, string, error) {
 	}
 }
 
-func getVarFile(s string) (string, string, error) {
+func getVarFile(s string, imp string) (string, string, error) {
 	parts := strings.SplitN(s, "=", 2)
 	name := parts[0]
 	if len(parts) == 1 {
 		return "", "", fmt.Errorf("ERROR: argument not in form <var>=<file> \"%s\".", s)
 	} else {
-		b, err := ioutil.ReadFile(parts[1])
-		if err != nil {
-			return "", "", err
-		}
-		return name, string(b), nil
+		return name, fmt.Sprintf("%s @'%s'", imp, strings.Replace(parts[1], "'", "''", -1)), nil
 	}
 }
 
@@ -256,11 +252,11 @@ func processArgs(givenArgs []string, config *config, vm *jsonnet.VM) (processArg
 				vm.ExtVar(name, content)
 			} else if arg == "--ext-str-file" {
 				next := nextArg(&i, args)
-				name, content, err := getVarFile(next)
+				name, content, err := getVarFile(next, "importstr")
 				if err != nil {
 					return processArgsStatusFailure, err
 				}
-				vm.ExtVar(name, content)
+				vm.ExtCode(name, content)
 			} else if arg == "--ext-code" {
 				next := nextArg(&i, args)
 				name, content, err := getVarVal(next)
@@ -270,7 +266,7 @@ func processArgs(givenArgs []string, config *config, vm *jsonnet.VM) (processArg
 				vm.ExtCode(name, content)
 			} else if arg == "--ext-code-file" {
 				next := nextArg(&i, args)
-				name, content, err := getVarFile(next)
+				name, content, err := getVarFile(next, "import")
 				if err != nil {
 					return processArgsStatusFailure, err
 				}
@@ -284,11 +280,11 @@ func processArgs(givenArgs []string, config *config, vm *jsonnet.VM) (processArg
 				vm.TLAVar(name, content)
 			} else if arg == "--tla-str-file" {
 				next := nextArg(&i, args)
-				name, content, err := getVarFile(next)
+				name, content, err := getVarFile(next, "importstr")
 				if err != nil {
 					return processArgsStatusFailure, err
 				}
-				vm.TLAVar(name, content)
+				vm.TLACode(name, content)
 			} else if arg == "--tla-code" {
 				next := nextArg(&i, args)
 				name, content, err := getVarVal(next)
@@ -298,7 +294,7 @@ func processArgs(givenArgs []string, config *config, vm *jsonnet.VM) (processArg
 				vm.TLACode(name, content)
 			} else if arg == "--tla-code-file" {
 				next := nextArg(&i, args)
-				name, content, err := getVarFile(next)
+				name, content, err := getVarFile(next, "import")
 				if err != nil {
 					return processArgsStatusFailure, err
 				}


### PR DESCRIPTION
Instead of reading the files directly for --tla/ext-*-file, just add a
code snippet that does an import or importstr.

This makes relative imports work when the code-file path is not in the
current directory. It also makes the import lazy so if the arg/var is
not referenced, the file does not have to exist.

Fixes: google/jsonnet#452