### PR TITLE
Add C++-Jsonnet submodule for tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cpp-jsonnet"]
+	path = cpp-jsonnet
+	url = https://github.com/google/jsonnet.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_install:
   - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
 script:
   - $HOME/gopath/bin/goveralls -service=travis-ci
-  - ./tests.sh
+  - ./tests.sh --skip-go-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ before_install:
   - go get github.com/mattn/goveralls
   - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
 script:
-    - $HOME/gopath/bin/goveralls -service=travis-ci
+  - $HOME/gopath/bin/goveralls -service=travis-ci
+  - ./tests.sh

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This code is known to work on Go 1.8 and above. We recommend always using the ne
 
 ## Build instructions
 
-```
+```bash
 export GOPATH=$HOME/go-workspace
 mkdir -pv $GOPATH
 go get github.com/google/go-jsonnet
@@ -32,13 +32,19 @@ go build
 }
 ```
 
+## Running tests
+
+```bash
+./tests.sh  # Also runs `go test ./...`
+```
+
 ## Implementation Notes
 
 We are generating some helper classes on types by using
 http://clipperhouse.github.io/gen/.  Do the following to regenerate these if
 necessary:
 
-```
+```bash
 go get github.com/clipperhouse/gen
 go get github.com/clipperhouse/set
 export PATH=$PATH:$GOPATH/bin  # If you haven't already
@@ -49,6 +55,6 @@ go generate
 
 To regenerate the standard library, do:
 
-```
+```bash
 ./reset_stdast_go.sh && go run cmd/dumpstdlibast.go
 ```

--- a/tests.sh
+++ b/tests.sh
@@ -5,10 +5,12 @@ set -e
 export IMPLEMENTATION=go
 
 (cd jsonnet; go build)
-source tests_path.source
+
 export DISABLE_LIB_TESTS=true
 export DISABLE_FMT_TESTS=true
 export DISABLE_ERROR_TESTS=true
 export JSONNET_BIN="$PWD/jsonnet/jsonnet"
-cd "$TESTS_PATH"
-./tests.sh
+
+git submodule update --recursive cpp-jsonnet
+cd cpp-jsonnet
+exec ./tests.sh

--- a/tests.sh
+++ b/tests.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+go test ./...
+
 export IMPLEMENTATION=go
 
 (cd jsonnet; go build)

--- a/tests.sh
+++ b/tests.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-go test ./...
+[ "$1" = "--skip-go-test" ] || go test ./...
 
 export IMPLEMENTATION=go
 


### PR DESCRIPTION
Also:

- Run `tests.sh` in travis-ci.
- `tests.sh` updates the submodule and run its tests against go-jsonnet.
- `tests.sh` also runs `go test ./...` (but not in travis-ci, which does so via goverage).
- Update `README.md` to explain how to run tests.

Currently, the submodule points to the latest Jsonnet release, v0.9.5.