### PR TITLE
godoc.org-compatible ast package

### DIFF
--- a/dump/dump_test.go
+++ b/dump/dump_test.go
@@ -454,3 +454,26 @@ var Obj = &struct { Foo *Zeo; Bar *Zeo }{
 		}
 	}
 }
+
+func TestSdumpLargeDefinition(t *testing.T) {
+	type largeStruct struct {
+		ABCDEFGHIJKLMNOBQRSTUVWXYZ0 int
+		ABCDEFGHIJKLMNOBQRSTUVWXYZ1 int
+		ABCDEFGHIJKLMNOBQRSTUVWXYZ2 int
+		ABCDEFGHIJKLMNOBQRSTUVWXYZ3 int
+		ABCDEFGHIJKLMNOBQRSTUVWXYZ4 int
+	}
+	got := Sdump(&largeStruct{1, 2, 3, 4, 5})
+	want := `var Obj = _Obj
+var _Obj = &largeStruct{
+	ABCDEFGHIJKLMNOBQRSTUVWXYZ0: int(1),
+	ABCDEFGHIJKLMNOBQRSTUVWXYZ1: int(2),
+	ABCDEFGHIJKLMNOBQRSTUVWXYZ2: int(3),
+	ABCDEFGHIJKLMNOBQRSTUVWXYZ3: int(4),
+	ABCDEFGHIJKLMNOBQRSTUVWXYZ4: int(5),
+}
+`
+	if got != want {
+		t.Errorf("got : \n%#v\n, want : \n%#v", got, want)
+	}
+}


### PR DESCRIPTION
Change the dump code so that it hides the values of variable
definitions if they're large. This means that godoc.org should
be able to deal with the output, and the godoc output is
readable without needing to read through a huge struct literal definition.

Other approaches might be to always generate an extra variable
(seems unnecessary) or to pass to writer explicitly to the dump
methods rather than swapping s.w out temporarily. The former
seems unnecessarily intrusive to the usual output; the latter
seemed unnecessarily intrusive to the source itself.
YMMV.