### PR TITLE
[BUG] Support *ast.ObjectComp and *ast.Parens in Node.Children()

### DIFF
--- a/parser/context.go
+++ b/parser/context.go
@@ -263,7 +263,7 @@ func specialChildren(node ast.Node) []ast.Node {
 	case *ast.ArrayComp:
 		return []ast.Node{node.Body}
 	case *ast.ObjectComp:
-
+		return inObjectFieldsChildren(node.Fields)
 	case *ast.Self:
 		return nil
 	case *ast.SuperIndex:
@@ -273,6 +273,8 @@ func specialChildren(node ast.Node) []ast.Node {
 	case *ast.Unary:
 		return nil
 	case *ast.Var:
+		return nil
+	case *ast.Parens:
 		return nil
 	}
 	panic(fmt.Sprintf("specialChildren: Unknown node %#v", node))


### PR DESCRIPTION
ref: https://github.com/google/go-jsonnet/issues/226