### PR TITLE
Lex fodder in a manner compatible with C++

### DIFF
--- a/ast/fodder.go
+++ b/ast/fodder.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2018 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ast provides AST nodes and ancillary structures and algorithms.
+package ast
+
+import (
+	"fmt"
+)
+
+// Fodder
+
+// FodderKind is an enum.
+type FodderKind int
+
+const (
+	// FodderLineEnd represents a line ending.
+	//
+	// It indicates that the next token, paragraph, or interstitial
+	// should be on a new line.
+	//
+	// A single comment string is allowed, which flows before the new line.
+	//
+	// The LineEnd fodder specifies the indentation level and vertical spacing
+	// before whatever comes next.
+	FodderLineEnd FodderKind = iota
+
+	// FodderInterstitial represents a comment in middle of a line.
+	//
+	// They must be /* C-style */ comments.
+	//
+	// If it follows a token (i.e., it is the first fodder element) then it
+	// appears after the token on the same line.  If it follows another
+	// interstitial, it will also flow after it on the same line.  If it follows
+	// a new line or a paragraph, it is the first thing on the following line,
+	// after the blank lines and indentation specified by the previous fodder.
+	//
+	// There is exactly one comment string.
+	FodderInterstitial
+
+	// FodderParagraph represents a comment consisting of at least one line.
+	//
+	// // and # style commes have exactly one line.  C-style comments can have
+	// more than one line.
+	//
+	// All lines of the comment are indented according to the indentation level
+	// of the previous new line / paragraph fodder.
+	//
+	// The Paragraph fodder specifies the indentation level and vertical spacing
+	// before whatever comes next.
+	FodderParagraph
+)
+
+// FodderElement is a single piece of fodder.
+type FodderElement struct {
+	Kind    FodderKind
+	Blanks  int
+	Indent  int
+	Comment []string
+}
+
+// MakeFodderElement is a helper function that checks some preconditions.
+func MakeFodderElement(kind FodderKind, blanks int, indent int, comment []string) FodderElement {
+	if kind == FodderLineEnd && len(comment) > 1 {
+		panic(fmt.Sprintf("FodderLineEnd but comment == %v.", comment))
+	}
+	if kind == FodderInterstitial && blanks > 0 {
+		panic(fmt.Sprintf("FodderInterstitial but blanks == %d", blanks))
+	}
+	if kind == FodderInterstitial && indent > 0 {
+		panic(fmt.Sprintf("FodderInterstitial but indent == %d", blanks))
+	}
+	if kind == FodderInterstitial && len(comment) != 1 {
+		panic(fmt.Sprintf("FodderInterstitial but comment == %v.", comment))
+	}
+	if kind == FodderParagraph && len(comment) == 0 {
+		panic(fmt.Sprintf("FodderParagraph but comment was empty"))
+	}
+	return FodderElement{Kind: kind, Blanks: blanks, Indent: indent, Comment: comment}
+}
+
+// Fodder is stuff that is usually thrown away by lexers/preprocessors but is
+// kept so that the source can be round tripped with near full fidelity.
+type Fodder []FodderElement
+
+// FodderHasCleanEndline is true if the fodder doesn't end with an interstitial.
+func FodderHasCleanEndline(fodder Fodder) bool {
+	return len(fodder) > 0 && fodder[len(fodder)-1].Kind != FodderInterstitial
+}
+
+// FodderAppend appends to the fodder but preserves constraints.
+//
+// See FodderConcat below.
+func FodderAppend(a *Fodder, elem FodderElement) {
+	if FodderHasCleanEndline(*a) && elem.Kind == FodderLineEnd {
+		if len(elem.Comment) > 0 {
+			// The line end had a comment, so create a single line paragraph for it.
+			*a = append(*a, MakeFodderElement(FodderParagraph, elem.Blanks, elem.Indent, elem.Comment))
+		} else {
+			back := &(*a)[len(*a)-1]
+			// Merge it into the previous line end.
+			back.Indent = elem.Indent
+			back.Blanks += elem.Blanks
+		}
+	} else {
+		if !FodderHasCleanEndline(*a) && elem.Kind == FodderParagraph {
+			*a = append(*a, MakeFodderElement(FodderLineEnd, 0, elem.Indent, []string{}))
+		}
+		*a = append(*a, elem)
+	}
+}
+
+// FodderConcat concats the two fodders but also preserves constraints.
+//
+// Namely, a FodderLineEnd is not allowed to follow a FodderParagraph or a FodderLineEnd.
+func FodderConcat(a Fodder, b Fodder) Fodder {
+	if len(a) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return a
+	}
+	r := a
+	// Carefully add the first element of b.
+	FodderAppend(&r, b[0])
+	// Add the rest of b.
+	for i := 1; i < len(b); i++ {
+		r = append(r, b[i])
+	}
+	return r
+}
+
+// FodderMoveFront moves b to the front of a.
+func FodderMoveFront(a *Fodder, b *Fodder) {
+	*a = FodderConcat(*b, *a)
+	*b = Fodder{}
+}
+
+// FodderEnsureCleanNewline adds a LineEnd to the fodder if necessary.
+func FodderEnsureCleanNewline(fodder *Fodder) {
+	if !FodderHasCleanEndline(*fodder) {
+		FodderAppend(fodder, MakeFodderElement(FodderLineEnd, 0, 0, []string{}))
+	}
+}
+
+// FodderElementCountNewlines returns the number of new line chars represented by the fodder element
+func FodderElementCountNewlines(elem FodderElement) int {
+	switch elem.Kind {
+	case FodderInterstitial:
+		return 0
+	case FodderLineEnd:
+		return 1
+	case FodderParagraph:
+		return len(elem.Comment) + elem.Blanks
+	}
+	panic(fmt.Sprintf("Unknown FodderElement kind %d", elem.Kind))
+}
+
+// FodderCountNewlines returns the number of new line chars represented by the fodder.
+func FodderCountNewlines(fodder Fodder) int {
+	sum := 0
+	for _, elem := range fodder {
+		sum += FodderElementCountNewlines(elem)
+	}
+	return sum
+}

--- a/ast/fodder.go
+++ b/ast/fodder.go
@@ -53,7 +53,7 @@ const (
 
 	// FodderParagraph represents a comment consisting of at least one line.
 	//
-	// // and # style commes have exactly one line.  C-style comments can have
+	// // and # style comments have exactly one line.  C-style comments can have
 	// more than one line.
 	//
 	// All lines of the comment are indented according to the indentation level

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -27,27 +27,6 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// Fodder
-//
-// Fodder is stuff that is usually thrown away by lexers/preprocessors but is
-// kept so that the source can be round tripped with full fidelity.
-type fodderKind int
-
-const (
-	fodderWhitespace fodderKind = iota
-	fodderCommentC
-	fodderCommentCpp
-	fodderCommentHash
-)
-
-type fodderElement struct {
-	kind fodderKind
-	data string
-}
-
-type fodder []fodderElement
-
-// ---------------------------------------------------------------------------
 // Token
 
 type tokenKind int
@@ -154,9 +133,9 @@ func (tk tokenKind) String() string {
 }
 
 type token struct {
-	kind   tokenKind // The type of the token
-	fodder fodder    // Any fodder the occurs before this token
-	data   string    // Content of the token if it is not a keyword
+	kind   tokenKind  // The type of the token
+	fodder ast.Fodder // Any fodder that occurs before this token
+	data   string     // Content of the token if it is not a keyword
 
 	// Extra info for when kind == tokenStringBlock
 	stringBlockIndent     string // The sequence of whitespace that indented the block.
@@ -209,6 +188,47 @@ func isSymbol(r rune) bool {
 	return false
 }
 
+func isHorzWs(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\r'
+}
+
+func isWs(r rune) bool {
+	return r == '\n' || isHorzWs(r)
+}
+
+// stripWs strips whitespace from both ends of a string, but only up to margin
+// on the left hand side.  E.g., stripWs("  foo ", 1) == " foo".
+func stripWs(s string, margin int) string {
+	runes := []rune(s)
+	if len(s) == 0 {
+		return s // Avoid underflow below.
+	}
+	i := 0
+	for i < len(runes) && isHorzWs(runes[i]) && i < margin {
+		i++
+	}
+	j := len(runes)
+	for j > i && isHorzWs(runes[j-1]) {
+		j--
+	}
+	return string(runes[i : j+1])
+}
+
+// Split a string by \n and also strip left (up to margin) & right whitespace from each line. */
+func lineSplit(s string, margin int) []string {
+	var ret []string
+	var buf bytes.Buffer
+	for _, r := range s {
+		if r == '\n' {
+			ret = append(ret, stripWs(buf.String(), margin))
+			buf.Reset()
+		} else {
+			buf.WriteRune(r)
+		}
+	}
+	return append(ret, stripWs(buf.String(), margin))
+}
+
 // Check that b has at least the same whitespace prefix as a and returns the
 // amount of this whitespace, otherwise returns 0.  If a has no whitespace
 // prefix than return 0.
@@ -254,9 +274,12 @@ type lexer struct {
 	tokens Tokens // The tokens that we've generated so far
 
 	// Information about the token we are working on right now
-	fodder        fodder
+	fodder        ast.Fodder
 	tokenStart    int
 	tokenStartLoc ast.Location
+
+	// Was the last rune the first rune on a line (ignoring initial whitespace).
+	freshLine bool
 }
 
 const lexEOF = -1
@@ -269,6 +292,7 @@ func makeLexer(fn string, input string) *lexer {
 		pos:           position{byteNo: 0, lineNo: 1, lineStart: 0},
 		prev:          position{byteNo: lexEOF, lineNo: 0, lineStart: 0},
 		tokenStartLoc: ast.Location{Line: 1, Column: 1},
+		freshLine:     true,
 	}
 }
 
@@ -284,6 +308,11 @@ func (l *lexer) next() rune {
 	if r == '\n' {
 		l.pos.lineStart = l.pos.byteNo
 		l.pos.lineNo++
+		l.freshLine = true
+	} else if l.freshLine {
+		if !isWs(r) {
+			l.freshLine = false
+		}
 	}
 	return r
 }
@@ -302,6 +331,7 @@ func (l *lexer) peek() rune {
 }
 
 // backup steps back one rune. Can only be called once per call of next.
+// It also does not recover the previous value of freshLine.
 func (l *lexer) backup() {
 	if l.prev.byteNo == lexEOF {
 		panic("backup called with no valid previous rune")
@@ -342,7 +372,7 @@ func (l *lexer) emitFullToken(kind tokenKind, data, stringBlockIndent, stringBlo
 		stringBlockTermIndent: stringBlockTermIndent,
 		loc: ast.MakeLocationRange(l.fileName, l.source, l.tokenStartLoc, l.location()),
 	})
-	l.fodder = fodder{}
+	l.fodder = ast.Fodder{}
 }
 
 func (l *lexer) emitToken(kind tokenKind) {
@@ -350,28 +380,75 @@ func (l *lexer) emitToken(kind tokenKind) {
 	l.resetTokenStart()
 }
 
-func (l *lexer) addWhitespaceFodder() {
-	fodderData := l.input[l.tokenStart:l.pos.byteNo]
-	if len(l.fodder) == 0 || l.fodder[len(l.fodder)-1].kind != fodderWhitespace {
-		l.fodder = append(l.fodder, fodderElement{kind: fodderWhitespace, data: fodderData})
-	} else {
-		l.fodder[len(l.fodder)-1].data += fodderData
-	}
-	l.resetTokenStart()
-}
-
-func (l *lexer) addCommentFodder(kind fodderKind) {
-	fodderData := l.input[l.tokenStart:l.pos.byteNo]
-	l.fodder = append(l.fodder, fodderElement{kind: kind, data: fodderData})
-	l.resetTokenStart()
-}
-
-func (l *lexer) addFodder(kind fodderKind, data string) {
-	l.fodder = append(l.fodder, fodderElement{kind: kind, data: data})
+func (l *lexer) addFodder(kind ast.FodderKind, blanks int, indent int, comment []string) {
+	elem := ast.MakeFodderElement(kind, blanks, indent, comment)
+	l.fodder = append(l.fodder, elem)
 }
 
 func (l *lexer) makeStaticErrorPoint(msg string, loc ast.Location) StaticError {
 	return StaticError{Msg: msg, Loc: ast.MakeLocationRange(l.fileName, l.source, loc, loc)}
+}
+
+// lexWs consumes all whitespace and returns the number of \n and number of
+// spaces after last \n.  It also converts \t to spaces.
+// The parameter 'r' is the rune that begins the whitespace.
+func (l *lexer) lexWs() (int, int) {
+	r := l.next()
+	indent := 0
+	newLines := 0
+	for ; isWs(r); r = l.next() {
+		switch r {
+		case '\r':
+			// Ignore.
+			break
+
+		case '\n':
+			indent = 0
+			newLines++
+			break
+
+		case ' ':
+			indent++
+			break
+
+		// This only works for \t at the beginning of lines, but we strip it everywhere else
+		// anyway.  The only case where this will cause a problem is spaces followed by \t
+		// at the beginning of a line.  However that is rare, ill-advised, and if re-indentation
+		// is enabled it will be fixed later.
+		case '\t':
+			indent += 8
+			break
+		}
+	}
+	l.backup()
+	return newLines, indent
+}
+
+// lexUntilNewLine consumes all text until the end of the line and returns the
+// number of newlines after that as well as the next indent.
+func (l *lexer) lexUntilNewline() (string, int, int) {
+	// Compute 'text'.
+	var buf bytes.Buffer
+	lastNonSpace := 0
+	for r := l.next(); r != lexEOF && r != '\n'; r = l.next() {
+		buf.WriteRune(r)
+		if !isHorzWs(r) {
+			lastNonSpace = buf.Len()
+		}
+	}
+	l.backup()
+	// Trim whitespace off the end.
+	buf.Truncate(lastNonSpace)
+	text := buf.String()
+
+	// Consume the '\n' and following indent.
+	var newLines int
+	newLines, indent := l.lexWs()
+	blanks := 0
+	if newLines > 0 {
+		blanks = newLines - 1
+	}
+	return text, blanks, indent
 }
 
 // lexNumber will consume a number and emit a token.  It is assumed
@@ -548,34 +625,70 @@ func (l *lexer) lexSymbol() error {
 	r := l.next()
 
 	// Single line C++ style comment
-	if r == '/' && l.peek() == '/' {
-		l.next()
-		l.resetTokenStart() // Throw out the leading //
-		for r = l.next(); r != lexEOF && r != '\n'; r = l.next() {
+	if r == '#' || (r == '/' && l.peek() == '/') {
+		comment, blanks, indent := l.lexUntilNewline()
+		var k ast.FodderKind
+		if l.freshLine {
+			k = ast.FodderParagraph
+		} else {
+			k = ast.FodderLineEnd
 		}
-		// Leave the '\n' in the lexer to be fodder for the next round
-		l.backup()
-		l.addCommentFodder(fodderCommentCpp)
+		l.addFodder(k, blanks, indent, []string{string(r) + comment})
 		return nil
 	}
 
+	// C style comment (could be interstitial or paragraph comment)
 	if r == '/' && l.peek() == '*' {
+		margin := l.pos.byteNo - l.pos.lineStart
 		commentStartLoc := l.tokenStartLoc
-		l.next()            // consume the '*'
-		l.resetTokenStart() // Throw out the leading /*
-		for r = l.next(); ; r = l.next() {
+
+		r := l.next() // consume the initial '*'
+		for r = l.next(); r != '*' && l.peek() != '/'; r = l.next() {
 			if r == lexEOF {
-				return l.makeStaticErrorPoint("Multi-line comment has no terminating */",
+				return l.makeStaticErrorPoint(
+					"Multi-line comment has no terminating */",
 					commentStartLoc)
 			}
-			if r == '*' && l.peek() == '/' {
-				commentData := l.input[l.tokenStart : l.pos.byteNo-1] // Don't include trailing */
-				l.addFodder(fodderCommentC, commentData)
-				l.next()            // Skip past '/'
-				l.resetTokenStart() // Start next token at this point
-				return nil
-			}
 		}
+
+		l.next() // Consume trailing '/'
+		// Includes the "/*" and "*/".
+		comment := l.input[l.tokenStart:l.pos.byteNo]
+
+		newLinesAfter, indentAfter := l.lexWs()
+		if !strings.ContainsRune(comment, '\n') {
+			l.addFodder(ast.FodderInterstitial, 0, 0, []string{comment})
+			if newLinesAfter > 0 {
+				l.addFodder(ast.FodderLineEnd, newLinesAfter-1, indentAfter, []string{})
+			}
+		} else {
+			lines := lineSplit(comment, margin)
+			if lines[0][0] != '/' {
+				panic(fmt.Sprintf("Invalid parsing of C style comment %v", lines))
+			}
+			// Little hack to support FodderParagraphs with * down the LHS:
+			// Add a space to lines that start with a '*'
+			allStar := true
+			for _, l := range lines {
+				if l[0] != '*' {
+					allStar = false
+				}
+			}
+			if allStar {
+				for _, l := range lines {
+					if l[0] != '*' {
+						l = " " + l
+					}
+				}
+			}
+			if newLinesAfter == 0 {
+				// Ensure a line end after the paragraph.
+				newLinesAfter = 1
+				indentAfter = 0
+			}
+			l.addFodder(ast.FodderParagraph, newLinesAfter-1, indentAfter, lines)
+		}
+		return nil
 	}
 
 	if r == '|' && strings.HasPrefix(l.input[l.pos.byteNo:], "||") {
@@ -688,12 +801,22 @@ func Lex(fn string, input string) (Tokens, error) {
 	l := makeLexer(fn, input)
 
 	var err error
-
-	for r := l.next(); r != lexEOF; r = l.next() {
+	for true {
+		newLines, indent := l.lexWs()
+		// If it's the end of the file, discard final whitespace.
+		if l.peek() == lexEOF {
+			l.next()
+			l.resetTokenStart()
+			break
+		}
+		if newLines > 0 {
+			// Otherwise store whitespace in fodder.
+			blanks := newLines - 1
+			l.addFodder(ast.FodderLineEnd, blanks, indent, []string{})
+		}
+		l.resetTokenStart() // Don't include whitespace in actual token.
+		r := l.next()
 		switch r {
-		case ' ', '\t', '\r', '\n':
-			l.addWhitespaceFodder()
-			continue
 		case '{':
 			l.emitToken(tokenBraceL)
 		case '}':
@@ -791,19 +914,11 @@ func Lex(fn string, input string) (Tokens, error) {
 				}
 			}
 
-		case '#':
-			l.resetTokenStart() // Throw out the leading #
-			for r = l.next(); r != lexEOF && r != '\n'; r = l.next() {
-			}
-			// Leave the '\n' in the lexer to be fodder for the next round
-			l.backup()
-			l.addCommentFodder(fodderCommentHash)
-
 		default:
 			if isIdentifierFirst(r) {
 				l.backup()
 				l.lexIdentifier()
-			} else if isSymbol(r) {
+			} else if isSymbol(r) || r == '#' {
 				l.backup()
 				err = l.lexSymbol()
 				if err != nil {

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -211,7 +211,7 @@ func stripWs(s string, margin int) string {
 	for j > i && isHorzWs(runes[j-1]) {
 		j--
 	}
-	return string(runes[i : j+1])
+	return string(runes[i:j])
 }
 
 // Split a string by \n and also strip left (up to margin) & right whitespace from each line. */
@@ -643,7 +643,7 @@ func (l *lexer) lexSymbol() error {
 		commentStartLoc := l.tokenStartLoc
 
 		r := l.next() // consume the initial '*'
-		for r = l.next(); r != '*' && l.peek() != '/'; r = l.next() {
+		for r = l.next(); r != '*' || l.peek() != '/'; r = l.next() {
 			if r == lexEOF {
 				return l.makeStaticErrorPoint(
 					"Multi-line comment has no terminating */",
@@ -670,13 +670,13 @@ func (l *lexer) lexSymbol() error {
 			// Add a space to lines that start with a '*'
 			allStar := true
 			for _, l := range lines {
-				if l[0] != '*' {
+				if len(l) == 0 || l[0] != '*' {
 					allStar = false
 				}
 			}
 			if allStar {
 				for _, l := range lines {
-					if l[0] != '*' {
+					if l[0] == '*' {
 						l = " " + l
 					}
 				}

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -620,6 +620,33 @@ func TestCComment(t *testing.T) {
 	})
 }
 
+func TestCCommentTooShort(t *testing.T) {
+	SingleTest(t, "/*/", "snippet:1:1 Multi-line comment has no terminating */", Tokens{})
+}
+
+func TestCCommentMinimal(t *testing.T) {
+	SingleTest(t, "/**/", "", Tokens{
+		{kind: tokenEndOfFile, fodder: ast.Fodder{{Kind: ast.FodderInterstitial, Comment: []string{"/**/"}}}},
+	})
+}
+
+func TestCCommentJustSlash(t *testing.T) {
+	SingleTest(t, "/*/*/", "", Tokens{
+		{kind: tokenEndOfFile, fodder: ast.Fodder{{Kind: ast.FodderInterstitial, Comment: []string{"/*/*/"}}}},
+	})
+}
+func TestCCommentSpaceSlash(t *testing.T) {
+	SingleTest(t, "/* /*/", "", Tokens{
+		{kind: tokenEndOfFile, fodder: ast.Fodder{{Kind: ast.FodderInterstitial, Comment: []string{"/* /*/"}}}},
+	})
+}
+
+func TestCCommentManyLines(t *testing.T) {
+	SingleTest(t, "/*\n\n*/", "", Tokens{
+		{kind: tokenEndOfFile, fodder: ast.Fodder{{Kind: ast.FodderParagraph, Comment: []string{"/*", "", "*/"}}}},
+	})
+}
+
 func TestCCommentNoTerm(t *testing.T) {
 	SingleTest(t, "/* hi", "snippet:1:1 Multi-line comment has no terminating */", Tokens{})
 }

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -17,6 +17,8 @@ package parser
 
 import (
 	"testing"
+
+	"github.com/google/go-jsonnet/ast"
 )
 
 type lexTest struct {
@@ -31,93 +33,6 @@ var (
 )
 
 var lexTests = []lexTest{
-	{"empty", "", Tokens{}, ""},
-	{"whitespace", "  \t\n\r\r\n", Tokens{}, ""},
-
-	{"brace L", "{", Tokens{{kind: tokenBraceL, data: "{"}}, ""},
-	{"brace R", "}", Tokens{{kind: tokenBraceR, data: "}"}}, ""},
-	{"bracket L", "[", Tokens{{kind: tokenBracketL, data: "["}}, ""},
-	{"bracket R", "]", Tokens{{kind: tokenBracketR, data: "]"}}, ""},
-	{"colon", ":", Tokens{{kind: tokenOperator, data: ":"}}, ""},
-	{"colon2", "::", Tokens{{kind: tokenOperator, data: "::"}}, ""},
-	{"colon3", ":::", Tokens{{kind: tokenOperator, data: ":::"}}, ""},
-	{"arrow right", "->", Tokens{{kind: tokenOperator, data: "->"}}, ""},
-	{"less than minus", "<-", Tokens{{kind: tokenOperator, data: "<"},
-		{kind: tokenOperator, data: "-"}}, ""},
-	{"comma", ",", Tokens{{kind: tokenComma, data: ","}}, ""},
-	{"dollar", "$", Tokens{{kind: tokenDollar, data: "$"}}, ""},
-	{"dot", ".", Tokens{{kind: tokenDot, data: "."}}, ""},
-	{"paren L", "(", Tokens{{kind: tokenParenL, data: "("}}, ""},
-	{"paren R", ")", Tokens{{kind: tokenParenR, data: ")"}}, ""},
-	{"semicolon", ";", Tokens{{kind: tokenSemicolon, data: ";"}}, ""},
-
-	{"not 1", "!", Tokens{{kind: tokenOperator, data: "!"}}, ""},
-	{"not 2", "! ", Tokens{{kind: tokenOperator, data: "!"}}, ""},
-	{"not equal", "!=", Tokens{{kind: tokenOperator, data: "!="}}, ""},
-	{"tilde", "~", Tokens{{kind: tokenOperator, data: "~"}}, ""},
-	{"plus", "+", Tokens{{kind: tokenOperator, data: "+"}}, ""},
-	{"minus", "-", Tokens{{kind: tokenOperator, data: "-"}}, ""},
-
-	{"number 0", "0", Tokens{{kind: tokenNumber, data: "0"}}, ""},
-	{"number 1", "1", Tokens{{kind: tokenNumber, data: "1"}}, ""},
-	{"number 1.0", "1.0", Tokens{{kind: tokenNumber, data: "1.0"}}, ""},
-	{"number 0.10", "0.10", Tokens{{kind: tokenNumber, data: "0.10"}}, ""},
-	{"number 0e100", "0e100", Tokens{{kind: tokenNumber, data: "0e100"}}, ""},
-	{"number 1e100", "1e100", Tokens{{kind: tokenNumber, data: "1e100"}}, ""},
-	{"number 1.1e100", "1.1e100", Tokens{{kind: tokenNumber, data: "1.1e100"}}, ""},
-	{"number 1.1e-100", "1.1e-100", Tokens{{kind: tokenNumber, data: "1.1e-100"}}, ""},
-	{"number 1.1e+100", "1.1e+100", Tokens{{kind: tokenNumber, data: "1.1e+100"}}, ""},
-	{"number 0100", "0100", Tokens{
-		{kind: tokenNumber, data: "0"},
-		{kind: tokenNumber, data: "100"},
-	}, ""},
-	{"number 10+10", "10+10", Tokens{
-		{kind: tokenNumber, data: "10"},
-		{kind: tokenOperator, data: "+"},
-		{kind: tokenNumber, data: "10"},
-	}, ""},
-	{"number 1.+3", "1.+3", Tokens{}, "number 1.+3:1:3 Couldn't lex number, junk after decimal point: '+'"},
-	{"number 1e!", "1e!", Tokens{}, "number 1e!:1:3 Couldn't lex number, junk after 'E': '!'"},
-	{"number 1e+!", "1e+!", Tokens{}, "number 1e+!:1:4 Couldn't lex number, junk after exponent sign: '!'"},
-
-	{"double string \"hi\"", "\"hi\"", Tokens{{kind: tokenStringDouble, data: "hi"}}, ""},
-	{"double string \"hi nl\"", "\"hi\n\"", Tokens{{kind: tokenStringDouble, data: "hi\n"}}, ""},
-	{"double string \"hi\\\"\"", "\"hi\\\"\"", Tokens{{kind: tokenStringDouble, data: "hi\\\""}}, ""},
-	{"double string \"hi\\nl\"", "\"hi\\\n\"", Tokens{{kind: tokenStringDouble, data: "hi\\\n"}}, ""},
-	{"double string \"hi", "\"hi", Tokens{}, "double string \"hi:1:1 Unterminated String"},
-
-	{"single string 'hi'", "'hi'", Tokens{{kind: tokenStringSingle, data: "hi"}}, ""},
-	{"single string 'hi nl'", "'hi\n'", Tokens{{kind: tokenStringSingle, data: "hi\n"}}, ""},
-	{"single string 'hi\\''", "'hi\\''", Tokens{{kind: tokenStringSingle, data: "hi\\'"}}, ""},
-	{"single string 'hi\\nl'", "'hi\\\n'", Tokens{{kind: tokenStringSingle, data: "hi\\\n"}}, ""},
-	{"single string 'hi", "'hi", Tokens{}, "single string 'hi:1:1 Unterminated String"},
-
-	{"assert", "assert", Tokens{{kind: tokenAssert, data: "assert"}}, ""},
-	{"else", "else", Tokens{{kind: tokenElse, data: "else"}}, ""},
-	{"error", "error", Tokens{{kind: tokenError, data: "error"}}, ""},
-	{"false", "false", Tokens{{kind: tokenFalse, data: "false"}}, ""},
-	{"for", "for", Tokens{{kind: tokenFor, data: "for"}}, ""},
-	{"function", "function", Tokens{{kind: tokenFunction, data: "function"}}, ""},
-	{"if", "if", Tokens{{kind: tokenIf, data: "if"}}, ""},
-	{"import", "import", Tokens{{kind: tokenImport, data: "import"}}, ""},
-	{"importstr", "importstr", Tokens{{kind: tokenImportStr, data: "importstr"}}, ""},
-	{"in", "in", Tokens{{kind: tokenIn, data: "in"}}, ""},
-	{"local", "local", Tokens{{kind: tokenLocal, data: "local"}}, ""},
-	{"null", "null", Tokens{{kind: tokenNullLit, data: "null"}}, ""},
-	{"self", "self", Tokens{{kind: tokenSelf, data: "self"}}, ""},
-	{"super", "super", Tokens{{kind: tokenSuper, data: "super"}}, ""},
-	{"tailstrict", "tailstrict", Tokens{{kind: tokenTailStrict, data: "tailstrict"}}, ""},
-	{"then", "then", Tokens{{kind: tokenThen, data: "then"}}, ""},
-	{"true", "true", Tokens{{kind: tokenTrue, data: "true"}}, ""},
-
-	{"identifier", "foobar123", Tokens{{kind: tokenIdentifier, data: "foobar123"}}, ""},
-	{"identifier", "foo bar123", Tokens{{kind: tokenIdentifier, data: "foo"}, {kind: tokenIdentifier, data: "bar123"}}, ""},
-
-	{"c++ comment", "// hi", Tokens{}, ""},                                                                     // This test doesn't look at fodder (yet?)
-	{"hash comment", "# hi", Tokens{}, ""},                                                                     // This test doesn't look at fodder (yet?)
-	{"c comment", "/* hi */", Tokens{}, ""},                                                                    // This test doesn't look at fodder (yet?)
-	{"c comment no term", "/* hi", Tokens{}, "c comment no term:1:1 Multi-line comment has no terminating */"}, // This test doesn't look at fodder (yet?)
-
 	{
 		"block string spaces",
 		`|||
@@ -225,29 +140,32 @@ test
 		Tokens{},
 		"block string no ws:1:1 Text block's first line must start with whitespace",
 	},
+}
 
-	{"verbatim_string1", `@""`, Tokens{{kind: tokenVerbatimStringDouble, data: ""}}, ""},
-	{"verbatim_string2", `@''`, Tokens{{kind: tokenVerbatimStringSingle, data: ""}}, ""},
-	{"verbatim_string3", `@""""`, Tokens{{kind: tokenVerbatimStringDouble, data: `"`}}, ""},
-	{"verbatim_string4", `@''''`, Tokens{{kind: tokenVerbatimStringSingle, data: "'"}}, ""},
-	{"verbatim_string5", `@"\n"`, Tokens{{kind: tokenVerbatimStringDouble, data: "\\n"}}, ""},
-	{"verbatim_string6", `@"''"`, Tokens{{kind: tokenVerbatimStringDouble, data: "''"}}, ""},
-
-	{"verbatim_string_unterminated", `@"blah blah`, Tokens{}, "verbatim_string_unterminated:1:1 Unterminated String"},
-	{"verbatim_string_junk", `@blah blah`, Tokens{}, "verbatim_string_junk:1:1 Couldn't lex verbatim string, junk after '@': 98"},
-
-	{"op *", "*", Tokens{{kind: tokenOperator, data: "*"}}, ""},
-	{"op /", "/", Tokens{{kind: tokenOperator, data: "/"}}, ""},
-	{"op %", "%", Tokens{{kind: tokenOperator, data: "%"}}, ""},
-	{"op &", "&", Tokens{{kind: tokenOperator, data: "&"}}, ""},
-	{"op |", "|", Tokens{{kind: tokenOperator, data: "|"}}, ""},
-	{"op ^", "^", Tokens{{kind: tokenOperator, data: "^"}}, ""},
-	{"op =", "=", Tokens{{kind: tokenOperator, data: "="}}, ""},
-	{"op <", "<", Tokens{{kind: tokenOperator, data: "<"}}, ""},
-	{"op >", ">", Tokens{{kind: tokenOperator, data: ">"}}, ""},
-	{"op >==|", ">==|", Tokens{{kind: tokenOperator, data: ">==|"}}, ""},
-
-	{"junk", "💩", Tokens{}, "junk:1:1 Could not lex the character '\\U0001f4a9'"},
+func fodderEqual(f1 ast.Fodder, f2 ast.Fodder) bool {
+	if len(f1) != len(f2) {
+		return false
+	}
+	for i := range f1 {
+		if f1[i].Kind != f2[i].Kind {
+			return false
+		}
+		if f1[i].Blanks != f2[i].Blanks {
+			return false
+		}
+		if f1[i].Indent != f2[i].Indent {
+			return false
+		}
+		if len(f1[i].Comment) != len(f2[i].Comment) {
+			return false
+		}
+		for j := range f1[i].Comment {
+			if f1[i].Comment[j] != f2[i].Comment[j] {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func tokensEqual(ts1, ts2 Tokens) bool {
@@ -262,6 +180,9 @@ func tokensEqual(ts1, ts2 Tokens) bool {
 		if t1.data != t2.data {
 			return false
 		}
+		if !fodderEqual(t1.fodder, t2.fodder) {
+			return false
+		}
 		if t1.stringBlockIndent != t2.stringBlockIndent {
 			return false
 		}
@@ -272,24 +193,601 @@ func tokensEqual(ts1, ts2 Tokens) bool {
 	return true
 }
 
-func TestLex(t *testing.T) {
-	for _, test := range lexTests {
-		// Copy the test tokens and append an EOF token
-		testTokens := append(Tokens(nil), test.tokens...)
+func SingleTest(t *testing.T, input string, expectedError string, expected Tokens) {
+	// Copy the test tokens and append an EOF token
+	testTokens := append(Tokens(nil), expected...)
+	if len(testTokens) == 0 || testTokens[len(testTokens)-1].kind != tokenEndOfFile {
 		testTokens = append(testTokens, tEOF)
-		tokens, err := Lex(test.name, test.input)
-		var errString string
-		if err != nil {
-			errString = err.Error()
-		}
-		if errString != test.errString {
-			t.Errorf("%s: error result does not match. got\n\t%+v\nexpected\n\t%+v",
-				test.name, errString, test.errString)
-		}
-		if err == nil && !tokensEqual(tokens, testTokens) {
-			t.Errorf("%s: got\n\t%+v\nexpected\n\t%+v", test.name, tokens, testTokens)
-		}
+	}
+	tokens, err := Lex("snippet", input)
+	var errString string
+	if err != nil {
+		errString = err.Error()
+	}
+	if errString != expectedError {
+		t.Errorf("error result does not match. got\n\t%+v\nexpected\n\t%+v",
+			errString, expectedError)
+	}
+	if err == nil && !tokensEqual(tokens, testTokens) {
+		t.Errorf("got\n\t%+v\nexpected\n\t%+v", tokens, expected)
 	}
 }
 
-// TODO: test fodder, test position reporting
+// TODO: test position reporting
+
+func TestEmpty(t *testing.T) {
+	SingleTest(t, "", "", Tokens{})
+}
+
+func TestWhitespace(t *testing.T) {
+	SingleTest(t, "  \t\n\r\r\n", "", Tokens{})
+}
+
+func TestBraceL(t *testing.T) {
+	SingleTest(t, "{", "", Tokens{
+		{kind: tokenBraceL, data: "{"},
+	})
+}
+
+func TestBraceR(t *testing.T) {
+	SingleTest(t, "}", "", Tokens{
+		{kind: tokenBraceR, data: "}"},
+	})
+}
+
+func TestBracketL(t *testing.T) {
+	SingleTest(t, "[", "", Tokens{
+		{kind: tokenBracketL, data: "["},
+	})
+}
+
+func TestBracketR(t *testing.T) {
+	SingleTest(t, "]", "", Tokens{
+		{kind: tokenBracketR, data: "]"},
+	})
+}
+
+func TestColon(t *testing.T) {
+	SingleTest(t, ":", "", Tokens{
+		{kind: tokenOperator, data: ":"},
+	})
+}
+
+func TestColon2(t *testing.T) {
+	SingleTest(t, "::", "", Tokens{
+		{kind: tokenOperator, data: "::"},
+	})
+}
+
+func TestColon3(t *testing.T) {
+	SingleTest(t, ":::", "", Tokens{
+		{kind: tokenOperator, data: ":::"},
+	})
+}
+
+func TestArrowright(t *testing.T) {
+	SingleTest(t, "->", "", Tokens{
+		{kind: tokenOperator, data: "->"},
+	})
+}
+
+func TestLessthanminus(t *testing.T) {
+	SingleTest(t, "<-", "", Tokens{
+		{kind: tokenOperator, data: "<"},
+		{kind: tokenOperator, data: "-"},
+	})
+}
+
+func TestComma(t *testing.T) {
+	SingleTest(t, ",", "", Tokens{
+		{kind: tokenComma, data: ","},
+	})
+}
+
+func TestDollar(t *testing.T) {
+	SingleTest(t, "$", "", Tokens{
+		{kind: tokenDollar, data: "$"},
+	})
+}
+
+func TestDot(t *testing.T) {
+	SingleTest(t, ".", "", Tokens{
+		{kind: tokenDot, data: "."},
+	})
+}
+
+func TestParenL(t *testing.T) {
+	SingleTest(t, "(", "", Tokens{
+		{kind: tokenParenL, data: "("},
+	})
+}
+
+func TestParenR(t *testing.T) {
+	SingleTest(t, ")", "", Tokens{
+		{kind: tokenParenR, data: ")"},
+	})
+}
+
+func TestSemicolon(t *testing.T) {
+	SingleTest(t, ";", "", Tokens{
+		{kind: tokenSemicolon, data: ";"},
+	})
+}
+
+func TestNot1(t *testing.T) {
+	SingleTest(t, "!", "", Tokens{
+		{kind: tokenOperator, data: "!"},
+	})
+}
+
+func TestNot2(t *testing.T) {
+	SingleTest(t, "! ", "", Tokens{
+		{kind: tokenOperator, data: "!"},
+	})
+}
+
+func TestNotequal(t *testing.T) {
+	SingleTest(t, "!=", "", Tokens{
+		{kind: tokenOperator, data: "!="},
+	})
+}
+
+func TestTilde(t *testing.T) {
+	SingleTest(t, "~", "", Tokens{
+		{kind: tokenOperator, data: "~"},
+	})
+}
+
+func TestPlus(t *testing.T) {
+	SingleTest(t, "+", "", Tokens{
+		{kind: tokenOperator, data: "+"},
+	})
+}
+
+func TestMinus(t *testing.T) {
+	SingleTest(t, "-", "", Tokens{
+		{kind: tokenOperator, data: "-"},
+	})
+}
+
+func TestNumber0(t *testing.T) {
+	SingleTest(t, "0", "", Tokens{
+		{kind: tokenNumber, data: "0"},
+	})
+}
+
+func TestNumber1(t *testing.T) {
+	SingleTest(t, "1", "", Tokens{
+		{kind: tokenNumber, data: "1"},
+	})
+}
+
+func TestNumber1_0(t *testing.T) {
+	SingleTest(t, "1.0", "", Tokens{
+		{kind: tokenNumber, data: "1.0"},
+	})
+}
+
+func TestNumber0_10(t *testing.T) {
+	SingleTest(t, "0.10", "", Tokens{
+		{kind: tokenNumber, data: "0.10"},
+	})
+}
+
+func TestNumber0e100(t *testing.T) {
+	SingleTest(t, "0e100", "", Tokens{
+		{kind: tokenNumber, data: "0e100"},
+	})
+}
+
+func TestNumber1e100(t *testing.T) {
+	SingleTest(t, "1e100", "", Tokens{
+		{kind: tokenNumber, data: "1e100"},
+	})
+}
+
+func TestNumber1_1e100(t *testing.T) {
+	SingleTest(t, "1.1e100", "", Tokens{
+		{kind: tokenNumber, data: "1.1e100"},
+	})
+}
+
+func TestNumber1_1e_100(t *testing.T) {
+	SingleTest(t, "1.1e-100", "", Tokens{
+		{kind: tokenNumber, data: "1.1e-100"},
+	})
+}
+
+func TestNumber1_1ep100(t *testing.T) {
+	SingleTest(t, "1.1e+100", "", Tokens{
+		{kind: tokenNumber, data: "1.1e+100"},
+	})
+}
+
+func TestNumber0100(t *testing.T) {
+	SingleTest(t, "0100", "", Tokens{
+		{kind: tokenNumber, data: "0"},
+		{kind: tokenNumber, data: "100"},
+	})
+}
+
+func TestNumber10p10(t *testing.T) {
+	SingleTest(t, "10+10", "", Tokens{
+		{kind: tokenNumber, data: "10"},
+		{kind: tokenOperator, data: "+"},
+		{kind: tokenNumber, data: "10"},
+	})
+}
+
+func TestNumber1_p3(t *testing.T) {
+	SingleTest(t, "1.+3", "snippet:1:3 Couldn't lex number, junk after decimal point: '+'", Tokens{})
+}
+
+func TestNumber1eExc(t *testing.T) {
+	SingleTest(t, "1e!", "snippet:1:3 Couldn't lex number, junk after 'E': '!'", Tokens{})
+}
+
+func TestNumber1epExc(t *testing.T) {
+	SingleTest(t, "1e+!", "snippet:1:4 Couldn't lex number, junk after exponent sign: '!'", Tokens{})
+}
+
+func TestDoublestring1(t *testing.T) {
+	SingleTest(t, "\"hi\"", "", Tokens{
+		{kind: tokenStringDouble, data: "hi"},
+	})
+}
+
+func TestDoublestring2(t *testing.T) {
+	SingleTest(t, "\"hi\n\"", "", Tokens{
+		{kind: tokenStringDouble, data: "hi\n"},
+	})
+}
+
+func TestDoublestring3(t *testing.T) {
+	SingleTest(t, "\"hi\\\"\"", "", Tokens{
+		{kind: tokenStringDouble, data: "hi\\\""},
+	})
+}
+
+func TestDoublestring4(t *testing.T) {
+	SingleTest(t, "\"hi\\\n\"", "", Tokens{
+		{kind: tokenStringDouble, data: "hi\\\n"},
+	})
+}
+
+func TestDoublestring5(t *testing.T) {
+	SingleTest(t, "\"hi", "snippet:1:1 Unterminated String", Tokens{})
+}
+
+func TestSinglestring1(t *testing.T) {
+	SingleTest(t, "'hi'", "", Tokens{
+		{kind: tokenStringSingle, data: "hi"},
+	})
+}
+
+func TestSinglestring2(t *testing.T) {
+	SingleTest(t, "'hi\n'", "", Tokens{
+		{kind: tokenStringSingle, data: "hi\n"},
+	})
+}
+
+func TestSinglestring3(t *testing.T) {
+	SingleTest(t, "'hi\\''", "", Tokens{
+		{kind: tokenStringSingle, data: "hi\\'"},
+	})
+}
+
+func TestSinglestring4(t *testing.T) {
+	SingleTest(t, "'hi\\\n'", "", Tokens{
+		{kind: tokenStringSingle, data: "hi\\\n"},
+	})
+}
+
+func TestSinglestring5(t *testing.T) {
+	SingleTest(t, "'hi", "snippet:1:1 Unterminated String", Tokens{})
+}
+
+func TestAssert(t *testing.T) {
+	SingleTest(t, "assert", "", Tokens{
+		{kind: tokenAssert, data: "assert"},
+	})
+}
+
+func TestElse(t *testing.T) {
+	SingleTest(t, "else", "", Tokens{
+		{kind: tokenElse, data: "else"},
+	})
+}
+
+func TestError(t *testing.T) {
+	SingleTest(t, "error", "", Tokens{
+		{kind: tokenError, data: "error"},
+	})
+}
+
+func TestFalse(t *testing.T) {
+	SingleTest(t, "false", "", Tokens{
+		{kind: tokenFalse, data: "false"},
+	})
+}
+
+func TestFor(t *testing.T) {
+	SingleTest(t, "for", "", Tokens{
+		{kind: tokenFor, data: "for"},
+	})
+}
+
+func TestFunction(t *testing.T) {
+	SingleTest(t, "function", "", Tokens{
+		{kind: tokenFunction, data: "function"},
+	})
+}
+
+func TestIf(t *testing.T) {
+	SingleTest(t, "if", "", Tokens{
+		{kind: tokenIf, data: "if"},
+	})
+}
+
+func TestImport(t *testing.T) {
+	SingleTest(t, "import", "", Tokens{
+		{kind: tokenImport, data: "import"},
+	})
+}
+
+func TestImportstr(t *testing.T) {
+	SingleTest(t, "importstr", "", Tokens{
+		{kind: tokenImportStr, data: "importstr"},
+	})
+}
+
+func TestIn(t *testing.T) {
+	SingleTest(t, "in", "", Tokens{
+		{kind: tokenIn, data: "in"},
+	})
+}
+
+func TestLocal(t *testing.T) {
+	SingleTest(t, "local", "", Tokens{
+		{kind: tokenLocal, data: "local"},
+	})
+}
+
+func TestNull(t *testing.T) {
+	SingleTest(t, "null", "", Tokens{
+		{kind: tokenNullLit, data: "null"},
+	})
+}
+
+func TestSelf(t *testing.T) {
+	SingleTest(t, "self", "", Tokens{
+		{kind: tokenSelf, data: "self"},
+	})
+}
+
+func TestSuper(t *testing.T) {
+	SingleTest(t, "super", "", Tokens{
+		{kind: tokenSuper, data: "super"},
+	})
+}
+
+func TestTailstrict(t *testing.T) {
+	SingleTest(t, "tailstrict", "", Tokens{
+		{kind: tokenTailStrict, data: "tailstrict"},
+	})
+}
+
+func TestThen(t *testing.T) {
+	SingleTest(t, "then", "", Tokens{
+		{kind: tokenThen, data: "then"},
+	})
+}
+
+func TestTrue(t *testing.T) {
+	SingleTest(t, "true", "", Tokens{
+		{kind: tokenTrue, data: "true"},
+	})
+}
+
+func TestIdentifier(t *testing.T) {
+	SingleTest(t, "foobar123", "", Tokens{
+		{kind: tokenIdentifier, data: "foobar123"},
+	})
+}
+
+func TestIdentifiers(t *testing.T) {
+	SingleTest(t, "foo bar123", "", Tokens{
+		{kind: tokenIdentifier, data: "foo"},
+		{kind: tokenIdentifier, data: "bar123"},
+	})
+}
+
+func TestCppComment(t *testing.T) {
+	SingleTest(t, "// hi", "", Tokens{
+		{kind: tokenEndOfFile, fodder: ast.Fodder{{Kind: ast.FodderLineEnd, Comment: []string{"// hi"}}}},
+	})
+}
+
+func TestHashComment(t *testing.T) {
+	SingleTest(t, "# hi", "", Tokens{
+		{kind: tokenEndOfFile, fodder: ast.Fodder{{Kind: ast.FodderLineEnd, Comment: []string{"# hi"}}}},
+	})
+}
+
+func TestCComment(t *testing.T) {
+	SingleTest(t, "/* hi */", "", Tokens{
+		{kind: tokenEndOfFile, fodder: ast.Fodder{{Kind: ast.FodderInterstitial, Comment: []string{"/* hi */"}}}},
+	})
+}
+
+func TestCCommentNoTerm(t *testing.T) {
+	SingleTest(t, "/* hi", "snippet:1:1 Multi-line comment has no terminating */", Tokens{})
+}
+
+func TestBlockStringSpaces(t *testing.T) {
+	SingleTest(t, "|||\n  test\n    more\n  |||\n    foo\n|||", "", Tokens{
+		{
+			kind:                  tokenStringBlock,
+			data:                  "test\n  more\n|||\n  foo\n",
+			stringBlockIndent:     "  ",
+			stringBlockTermIndent: "",
+		},
+	})
+}
+
+func TestBlockStringTabs(t *testing.T) {
+	SingleTest(t, "|||\n\ttest\n\t  more\n\t|||\n\t  foo\n|||", "", Tokens{
+		{
+			kind:                  tokenStringBlock,
+			data:                  "test\n  more\n|||\n  foo\n",
+			stringBlockIndent:     "\t",
+			stringBlockTermIndent: "",
+		},
+	})
+}
+
+func TestBlockStringMixed(t *testing.T) {
+	SingleTest(t, "|||\n\t  \ttest\n\t  \t  more\n\t  \t|||\n\t  \t  foo\n|||", "", Tokens{
+		{
+			kind:                  tokenStringBlock,
+			data:                  "test\n  more\n|||\n  foo\n",
+			stringBlockIndent:     "\t  \t",
+			stringBlockTermIndent: "",
+		},
+	})
+}
+
+func TestBlockStringBlanks(t *testing.T) {
+	SingleTest(t, "|||\n\n  test\n\n\n    more\n  |||\n    foo\n|||", "", Tokens{
+		{
+			kind:                  tokenStringBlock,
+			data:                  "\ntest\n\n\n  more\n|||\n  foo\n",
+			stringBlockIndent:     "  ",
+			stringBlockTermIndent: "",
+		},
+	})
+}
+
+func TestBlockStringBadIndent(t *testing.T) {
+	SingleTest(t, "|||\n  test\n foo\n|||", "snippet:1:1 Text block not terminated with |||", Tokens{})
+}
+
+func TestBlockStringEof(t *testing.T) {
+	SingleTest(t, "|||\n  test", "snippet:1:1 Unexpected EOF", Tokens{})
+}
+
+func TestBlockStringNotTerm(t *testing.T) {
+	SingleTest(t, "|||\n  test\n", "snippet:1:1 Text block not terminated with |||", Tokens{})
+}
+
+func TestBlockstringNoWs(t *testing.T) {
+	SingleTest(t, "|||\ntest\n|||", "snippet:1:1 Text block's first line must start with whitespace", Tokens{})
+}
+
+func TestVerbatimString1(t *testing.T) {
+	SingleTest(t, "@\"\"", "", Tokens{
+		{kind: tokenVerbatimStringDouble, data: ""},
+	})
+}
+
+func TestVerbatimString2(t *testing.T) {
+	SingleTest(t, "@''", "", Tokens{
+		{kind: tokenVerbatimStringSingle, data: ""},
+	})
+}
+
+func TestVerbatimString3(t *testing.T) {
+	SingleTest(t, "@\"\"\"\"", "", Tokens{
+		{kind: tokenVerbatimStringDouble, data: "\""},
+	})
+}
+
+func TestVerbatimString4(t *testing.T) {
+	SingleTest(t, "@''''", "", Tokens{
+		{kind: tokenVerbatimStringSingle, data: "'"},
+	})
+}
+
+func TestVerbatimString5(t *testing.T) {
+	SingleTest(t, "@\"\\n\"", "", Tokens{
+		{kind: tokenVerbatimStringDouble, data: "\\n"},
+	})
+}
+
+func TestVerbatimString6(t *testing.T) {
+	SingleTest(t, "@\"''\"", "", Tokens{
+		{kind: tokenVerbatimStringDouble, data: "''"},
+	})
+}
+
+func TestVerbatimStringUnterminated(t *testing.T) {
+	SingleTest(t, "@\"blah blah", "snippet:1:1 Unterminated String", Tokens{})
+}
+
+func TestVerbatimStringJunk(t *testing.T) {
+	SingleTest(t, "@blah blah", "snippet:1:1 Couldn't lex verbatim string, junk after '@': 98", Tokens{})
+}
+
+func TestOpStar(t *testing.T) {
+	SingleTest(t, "*", "", Tokens{
+		{kind: tokenOperator, data: "*"},
+	})
+}
+
+func TestOpSlash(t *testing.T) {
+	SingleTest(t, "/", "", Tokens{
+		{kind: tokenOperator, data: "/"},
+	})
+}
+
+func TestOpPercent(t *testing.T) {
+	SingleTest(t, "%", "", Tokens{
+		{kind: tokenOperator, data: "%"},
+	})
+}
+
+func TestOpAmp(t *testing.T) {
+	SingleTest(t, "&", "", Tokens{
+		{kind: tokenOperator, data: "&"},
+	})
+}
+
+func TestOpPipe(t *testing.T) {
+	SingleTest(t, "|", "", Tokens{
+		{kind: tokenOperator, data: "|"},
+	})
+}
+
+func TestOpCaret(t *testing.T) {
+	SingleTest(t, "^", "", Tokens{
+		{kind: tokenOperator, data: "^"},
+	})
+}
+
+func TestOpEqual(t *testing.T) {
+	SingleTest(t, "=", "", Tokens{
+		{kind: tokenOperator, data: "="},
+	})
+}
+
+func TestOpLessThan(t *testing.T) {
+	SingleTest(t, "<", "", Tokens{
+		{kind: tokenOperator, data: "<"},
+	})
+}
+
+func TestOpGreaterThan(t *testing.T) {
+	SingleTest(t, ">", "", Tokens{
+		{kind: tokenOperator, data: ">"},
+	})
+}
+
+func TestOpJunk(t *testing.T) {
+	SingleTest(t, ">==|", "", Tokens{
+		{kind: tokenOperator, data: ">==|"},
+	})
+}
+
+func TestJunk(t *testing.T) {
+	SingleTest(t, "💩", "snippet:1:1 Could not lex the character '\\U0001f4a9'", Tokens{})
+}


### PR DESCRIPTION
I also rewrote lexer_test to use individual tests for each case instead of iterating through an array.  While not as dense on the page, the density of information is about the same and this way you can get more useful stacktraces as well as easily select specific tests to run.