### PR TITLE
travis: Support building pushed branches

### DIFF
--- a/travisBuild.sh
+++ b/travisBuild.sh
@@ -1,14 +1,25 @@
 #!/usr/bin/env bash
 
-
-if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-  echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
+run_tests() {
   $HOME/gopath/bin/goveralls -service=travis-ci
   ./tests.sh --skip-go-test
-elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
-  echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
+}
+
+release() {
   env VERSION=$TRAVIS_TAG ./release.sh
+}
+
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  # Pull Requests.
+  echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
+  run_tests
+elif [ "$TRAVIS_TAG" == "" ]; then
+  # Pushed branches.
+  echo -e "Build Branch $TRAVIS_BRANCH"
+  run_tests
 else
-  echo -e 'Unknown build command for PR? ('$TRAVIS_PULL') Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
+  # $TRAVIS_PULL_REQUEST == "false" and $TRAVIS_TAG != "" -> Releases.
+  echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
+  release
 fi
 


### PR DESCRIPTION
This commit refactors travisBuild.sh to support building pushed branched on top
of PRs and tags.

This was prompted by enabling travis on a forked repository. The development
flow then becomes:
  - Fork google/go-jsonnet
  - Enable travis on forked repository
  - Push branch to forked repository
  - Travis runs on the pushed branch
  - Submit pull request once happy and tests pass in the forked repository

I tested 3 scenarii and they seem behave nicely:
  - Running CI for pushed branch
  - Running CI for tag
  - Running CI for a Pull Request

As a side note, the previous error path didn't work as intented:
  - The TRAVIS_PULL variable didn't exist
  - We weren't exiting with a non 0 value in the else branch, so the build
    succeeded instead of failing when travisBuild.sh didn't know what to do
    with the pushed branch