### PR TITLE
Expose Evaluate functions, to be able to reuse the AST from `SnippetToAST`

### DIFF
--- a/vm.go
+++ b/vm.go
@@ -96,6 +96,33 @@ const (
 	evalKindStream           = iota
 )
 
+func (vm *VM) Evaluate(node ast.Node) (output interface{}, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("(CRASH) %v\n%s", r, debug.Stack())
+		}
+	}()
+	return evaluate(node, vm.ext, vm.tla, vm.nativeFuncs, vm.MaxStack, vm.importer, vm.StringOutput)
+}
+
+func (vm *VM) EvaluateStream(node ast.Node) (output interface{}, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("(CRASH) %v\n%s", r, debug.Stack())
+		}
+	}()
+	return evaluateStream(node, vm.ext, vm.tla, vm.nativeFuncs, vm.MaxStack, vm.importer)
+}
+
+func (vm *VM) EvaluateMulti(node ast.Node) (output interface{}, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("(CRASH) %v\n%s", r, debug.Stack())
+		}
+	}()
+	return evaluateMulti(node, vm.ext, vm.tla, vm.nativeFuncs, vm.MaxStack, vm.importer, vm.StringOutput)
+}
+
 func (vm *VM) evaluateSnippet(filename string, snippet string, kind evalKind) (output interface{}, err error) {
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
Right now, SnippetToAST provides a `Node` but nothing consumes it it seems.

This is mostly to open the discussion. My goal is to use jsonnet as a reformatter in streaming objects.. Performance is going to be paramount for us, reusing the AST is a start.

Nice work in here by the way.. love the project :)