### PR TITLE
Add install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ feedback.
 
 This code is known to work on Go 1.8 and above. We recommend always using the newest stable release of Go.
 
+## Installing
+
+```
+go get github.com/google/go-jsonnet/jsonnet
+```
+
 ## Build instructions
 
 ```bash


### PR DESCRIPTION
This package doesn't seem to follow the somewhat standard practice of using /cmd/${folder}/ for installing binary packages. This is fine it just means that to quickly pull the binary locally with go you need to use github.com/google/go-jsonnet/jsonnet as the path.

This will remove the issue of having to do anything else such as pull fatih/color as well.

To verify I nuked faith/color and google/go-jsonnet from my GOPATH and ran the documented command. jsonnet is now in my path and I don't need to mess around with any manual steps.