### PR TITLE
Update x/sys to a newer version that supports Risc-V architecture

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,7 @@ require (
 	github.com/mattn/go-isatty v0.0.7 // indirect
 	github.com/sergi/go-diff v1.0.0
 	github.com/stretchr/testify v1.3.0 // indirect
+	golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2 // indirect
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,3 @@ require (
 	github.com/stretchr/testify v1.3.0 // indirect
 	golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2 // indirect
 )
-
-go 1.13

--- a/go.sum
+++ b/go.sum
@@ -16,3 +16,5 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 h1:DH4skfRX4EBpamg7iV4ZlCpblAHI6s6TDM39bFZumv8=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2 h1:T5DasATyLQfmbTpfEXx/IOL9vfjzW6up+ZDkmHvIf2s=
+golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Updating projects using libraries that were recently updated to support Risc-V.

Go upstream work is tracked on: https://github.com/golang/go/issues/27532

Risc-V software support tracker on https://github.com/carlosedp/riscv-bringup