### PR TITLE
Eliminate Bazel local repository for "cpp-jsonnet" submodule

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,10 +1,5 @@
 workspace(name = "google_jsonnet_go")
 
-local_repository(
-    name = "cpp_jsonnet",
-    path = "./cpp-jsonnet",
-)
-
 load(
     "@bazel_tools//tools/build_defs/repo:http.bzl",
     "http_archive",

--- a/astgen/BUILD.bazel
+++ b/astgen/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 genrule(
     name = "dumpstdlibast",
-    srcs = ["@cpp_jsonnet//stdlib"],
+    srcs = ["//cpp-jsonnet/stdlib"],
     outs = ["stdast.go"],
     cmd = "./$(location //cmd/dumpstdlibast) \"$<\" > \"$@\"",
     tools = ["//cmd/dumpstdlibast"],

--- a/c-bindings/BUILD.bazel
+++ b/c-bindings/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
         "libjsonnet.cpp",
     ],
     cdeps = [
-        "@cpp_jsonnet//include:libjsonnet",
+        "//cpp-jsonnet/include:libjsonnet",
     ],
     cgo = True,
     copts = ["-Wall -Icpp-jsonnet/include"],  # keep


### PR DESCRIPTION
Treating the "cpp-jsonnet" Git submodule as a separate local Bazel repository precludes use of the "go-jsonnet" repository from other workspaces, as Bazel misinterprets the relative path to the local
"cpp-jsonnet" repository. Instead, use the Git submodule content directly along the package path from the workspace root.

Thanks to @werkt for pointing out the root of the problem.