### PR TITLE
Allow use of "go-jsonnet" Bazel repository as an external dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Note that we maintain the Go-related Bazel targets with [the Gazelle tool](https
 
 After changing any dependencies within the files covered by this Go module, it is helpful to run _go mod tidy_ to ensure that the module declarations match the state of the Go source code. In order to synchronize the Bazel rules with material changes to the Go module, run the following command to invoke [Gazelle's `update-repos` command](https://github.com/bazelbuild/bazel-gazelle#update-repos):
 ```bash
-bazel run //:gazelle -- update-repos -from_file=go.mod
+bazel run //:gazelle -- update-repos -from_file=go.mod -to_macro=bazel/deps.bzl%jsonnet_go_dependencies
 ```
 
 Similarly, after adding or removing Go source files, it may be necessary to synchronize the Bazel rules by running the following command:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,84 +4,18 @@ load(
     "@bazel_tools//tools/build_defs/repo:http.bzl",
     "http_archive",
 )
-
-# Go and Gazelle
-http_archive(
-    name = "io_bazel_rules_go",
-    sha256 = "a82a352bffae6bee4e95f68a8d80a70e87f42c4741e6a448bec11998fcc82329",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.5/rules_go-0.18.5.tar.gz"],
+load(
+    "@google_jsonnet_go//bazel:repositories.bzl",
+    "jsonnet_go_repositories",
 )
 
-http_archive(
-    name = "bazel_gazelle",
-    sha256 = "3c681998538231a2d24d0c07ed5a7658cb72bfb5fd4bf9911157c0e9ac6a2687",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.17.0/bazel-gazelle-0.17.0.tar.gz"],
-)
+jsonnet_go_repositories()
 
 load(
-    "@io_bazel_rules_go//go:deps.bzl",
-    "go_register_toolchains",
-    "go_rules_dependencies",
+    "@google_jsonnet_go//bazel:deps.bzl",
+    "jsonnet_go_dependencies",
 )
 
-go_rules_dependencies()
+jsonnet_go_dependencies()
 
-go_register_toolchains()
-
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
-
-gazelle_dependencies()
-
-go_repository(
-    name = "com_github_davecgh_go_spew",
-    importpath = "github.com/davecgh/go-spew",
-    tag = "v1.1.0",
-)
-
-go_repository(
-    name = "com_github_fatih_color",
-    importpath = "github.com/fatih/color",
-    tag = "v1.7.0",
-)
-
-go_repository(
-    name = "com_github_mattn_go_colorable",
-    importpath = "github.com/mattn/go-colorable",
-    tag = "v0.1.1",
-)
-
-go_repository(
-    name = "com_github_mattn_go_isatty",
-    importpath = "github.com/mattn/go-isatty",
-    tag = "v0.0.7",
-)
-
-go_repository(
-    name = "com_github_pmezard_go_difflib",
-    importpath = "github.com/pmezard/go-difflib",
-    tag = "v1.0.0",
-)
-
-go_repository(
-    name = "com_github_sergi_go_diff",
-    importpath = "github.com/sergi/go-diff",
-    tag = "v1.0.0",
-)
-
-go_repository(
-    name = "com_github_stretchr_objx",
-    importpath = "github.com/stretchr/objx",
-    tag = "v0.1.0",
-)
-
-go_repository(
-    name = "com_github_stretchr_testify",
-    importpath = "github.com/stretchr/testify",
-    tag = "v1.3.0",
-)
-
-go_repository(
-    name = "org_golang_x_sys",
-    commit = "a9d3bda3a223",
-    importpath = "golang.org/x/sys",
-)
+#gazelle:repository_macro bazel/deps.bzl%jsonnet_go_dependencies

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -1,0 +1,69 @@
+load(
+    "@io_bazel_rules_go//go:deps.bzl",
+    "go_register_toolchains",
+    "go_rules_dependencies",
+)
+load(
+    "@bazel_gazelle//:deps.bzl",
+    "gazelle_dependencies",
+    "go_repository",
+)
+
+def jsonnet_go_dependencies():
+    go_rules_dependencies()
+    go_register_toolchains()
+    gazelle_dependencies()
+    go_repository(
+        name = "com_github_davecgh_go_spew",
+        importpath = "github.com/davecgh/go-spew",
+        sum = "h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=",
+        version = "v1.1.0",
+    )
+    go_repository(
+        name = "com_github_fatih_color",
+        importpath = "github.com/fatih/color",
+        sum = "h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=",
+        version = "v1.7.0",
+    )
+    go_repository(
+        name = "com_github_mattn_go_colorable",
+        importpath = "github.com/mattn/go-colorable",
+        sum = "h1:G1f5SKeVxmagw/IyvzvtZE4Gybcc4Tr1tf7I8z0XgOg=",
+        version = "v0.1.1",
+    )
+    go_repository(
+        name = "com_github_mattn_go_isatty",
+        importpath = "github.com/mattn/go-isatty",
+        sum = "h1:UvyT9uN+3r7yLEYSlJsbQGdsaB/a0DlgWP3pql6iwOc=",
+        version = "v0.0.7",
+    )
+    go_repository(
+        name = "com_github_pmezard_go_difflib",
+        importpath = "github.com/pmezard/go-difflib",
+        sum = "h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=",
+        version = "v1.0.0",
+    )
+    go_repository(
+        name = "com_github_sergi_go_diff",
+        importpath = "github.com/sergi/go-diff",
+        sum = "h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=",
+        version = "v1.0.0",
+    )
+    go_repository(
+        name = "com_github_stretchr_objx",
+        importpath = "github.com/stretchr/objx",
+        sum = "h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=",
+        version = "v0.1.0",
+    )
+    go_repository(
+        name = "com_github_stretchr_testify",
+        importpath = "github.com/stretchr/testify",
+        sum = "h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=",
+        version = "v1.3.0",
+    )
+    go_repository(
+        name = "org_golang_x_sys",
+        importpath = "golang.org/x/sys",
+        sum = "h1:T5DasATyLQfmbTpfEXx/IOL9vfjzW6up+ZDkmHvIf2s=",
+        version = "v0.0.0-20190531175056-4c3a928424d2",
+    )

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,0 +1,31 @@
+load(
+    "@bazel_tools//tools/build_defs/repo:http.bzl",
+    "http_archive",
+)
+
+def _maybe(repo_rule, name, **kwargs):
+    """Executes the given repository rule if it hasn't been executed already.
+    Args:
+      repo_rule: The repository rule to be executed (e.g.,
+          `native.git_repository`.)
+      name: The name of the repository to be defined by the rule.
+      **kwargs: Additional arguments passed directly to the repository rule.
+    """
+    if not native.existing_rule(name):
+        repo_rule(name = name, **kwargs)
+
+def jsonnet_go_repositories():
+    _maybe(
+        http_archive,
+        name = "io_bazel_rules_go",
+        sha256 = "e6f8cb2da438cc4899809b66ba96d57397ed871640fe5c848ca9c56190b7c8ba",
+        strip_prefix = "rules_go-8ea79bbd5e6ea09dc611c245d1dc09ef7ab7118a",
+        urls = ["https://github.com/bazelbuild/rules_go/archive/8ea79bbd5e6ea09dc611c245d1dc09ef7ab7118a.zip"],
+    )
+    _maybe(
+        http_archive,
+        name = "bazel_gazelle",
+        sha256 = "c5faf839dd1da0065ed7d44ac248b01ab5ffcd0db46e7193439906df68867c39",
+        strip_prefix = "bazel-gazelle-38bd65ead186af23549480d6189b89c7c53c023e",
+        urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/38bd65ead186af23549480d6189b89c7c53c023e.zip"],
+    )


### PR DESCRIPTION
In order to rely on the _go-jsonnet_ Bazel repository as an external dependency from other Bazel projects, until [it becomes possible to load a _WORKSPACE_ file](https://github.com/bazelbuild/bazel/issues/1943), it's necessary to first declare the repositories on which this repository depends (_rules_go_ and _gazelle_), and then to load file from those two repositories and call macros to initialize them.

Expose two files to handle these steps:
- _bazel/repositories.bzl_ . 
  Defines the `jsonnet_go_repositories` macro.
- _bazel/deps.bzl_ . 
  Defines the `jsonnet_go_dependencies` macro.

Use these files and the macros they define within this repository's _WORKSPACE_ file, as a dependent repository would do in its _WORKSPACE_ file.