### PR TITLE
feat(parser): export parser.Children

### DIFF
--- a/parser/context.go
+++ b/parser/context.go
@@ -1,0 +1,11 @@
+package parser
+
+import (
+	"github.com/google/go-jsonnet/ast"
+	"github.com/google/go-jsonnet/internal/parser"
+)
+
+// Children returns all children of a node. It supports ASTs before and after desugaring.
+func Children(node ast.Node) []ast.Node {
+	return parser.Children(node)
+}

--- a/toolutils/BUILD.bazel
+++ b/toolutils/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["ast.go"],
+    importpath = "github.com/google/go-jsonnet/toolutils",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//ast:go_default_library",
+        "//internal/parser:go_default_library",
+    ],
+)

--- a/toolutils/ast.go
+++ b/toolutils/ast.go
@@ -1,4 +1,5 @@
-package parser
+// Package toolutils includes several utilities handy for use in code analysis tools
+package toolutils
 
 import (
 	"github.com/google/go-jsonnet/ast"


### PR DESCRIPTION
As `parser` was moved to `internal/parser`, it is not possible to import it into
external projects anymore.

However, `parser.Children()` is handy to use in static analysis tools, so it is
worth exporting. This does that by adding a stub package
`github.com/google/go-jsonnet/parser` that wraps the internal function.

Signed-off-by: sh0rez <me@shorez.de>

Closes #326 