### PR TITLE
Bump officially supported Go version to 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 matrix:
   include:
     - go: 1.x
-    - go: 1.8.x
+    - go: 1.11.x
     - go: tip
     - name: "Bazel Check"
       go: 1.x

--- a/README.md
+++ b/README.md
@@ -49,15 +49,6 @@ For additional target platform names, see the per-Go release definitions [here](
 
 Additionally if any files were moved around, see the section [Keeping the Bazel files up to date](#keeping-the-bazel-files-up-to-date).
 
-## Build instructions (go 1.8 - 1.10)
-
-```bash
-go get -u github.com/google/go-jsonnet
-cd $GOPATH/src/github.com/google/go-jsonnet
-go get -u .
-go build ./cmd/jsonnet
-```
-
 ## Running tests
 
 ```bash


### PR DESCRIPTION
Go 1.8 has been unsupported for more than a year.