### PR TITLE
Add necessary files to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include vm.go
+include cpp-jsonnet/include/libjsonnet.h
+graft c-bindings


### PR DESCRIPTION
Here's a quick fix for #371 .  I've done the bare minimum required to create a sdist (or wheel if you have a way to build them) that can be pip installed.  To test:

```
python3 setup.py sdist
pip install dist/gojsonnet-0.15.0.tar.gz
```

You should then be able to `import _gojsonnet` in the Python REPL.

Fair warning, I have no idea why or how the c-bindings are finding `libjsonnet.h`, I mostly just followed the error messages and included the missing files until it worked.  If there's a better way to include that I'm happy to make changes.