### PR TITLE
builtins.go: Prevent int overflow in bounds checks for bitwise operators

### DIFF
--- a/builtins.go
+++ b/builtins.go
@@ -862,11 +862,11 @@ func liftBitwise(f func(int64, int64) int64) func(*interpreter, traceElement, va
 			return nil, err
 		}
 		if x.value < math.MinInt64 || x.value > math.MaxInt64 {
-			msg := fmt.Sprintf("Bitwise operator argument %v outside of range [%v, %v]", x.value, math.MinInt64, math.MaxInt64)
+			msg := fmt.Sprintf("Bitwise operator argument %v outside of range [%v, %v]", x.value, int64(math.MinInt64), int64(math.MaxInt64))
 			return nil, makeRuntimeError(msg, i.getCurrentStackTrace(trace))
 		}
 		if y.value < math.MinInt64 || y.value > math.MaxInt64 {
-			msg := fmt.Sprintf("Bitwise operator argument %v outside of range [%v, %v]", y.value, math.MinInt64, math.MaxInt64)
+			msg := fmt.Sprintf("Bitwise operator argument %v outside of range [%v, %v]", y.value, int64(math.MinInt64), int64(math.MaxInt64))
 			return nil, makeRuntimeError(msg, i.getCurrentStackTrace(trace))
 		}
 		return makeDoubleCheck(i, trace, float64(f(int64(x.value), int64(y.value))))


### PR DESCRIPTION
Fix #376