### PR TITLE
Replace `setup.py test` with pytest command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ matrix:
         - echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
         - curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
         - sudo apt-get update && sudo apt-get install bazel make
+        - sudo apt install python3-dev
+        - pip install -U pytest --user
       script: make all
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ matrix:
 
 before_install:
   - sudo apt install python3-dev
+  - pip install -U pytest
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
   - go get github.com/fatih/color

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
 
 before_install:
   - sudo apt install python3-dev
-  - pip install -U pytest
+  - pip install -U pytest --user
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
   - go get github.com/fatih/color

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ import os
 from setuptools import setup
 from setuptools import Extension
 from setuptools.command.build_ext import build_ext as BuildExt
+from setuptools.command.test import test as TestCommand
 from subprocess import Popen, PIPE
 
 DIR = os.path.abspath(os.path.dirname(__file__))
@@ -45,6 +46,10 @@ class BuildJsonnetExt(BuildExt):
 
         BuildExt.run(self)
 
+class NoopTestCommand(TestCommand):
+    def __init__(self, dist):
+        print("_gojsonnet does not support running tests with 'python setup.py test'. Please run 'pytest'.")
+
 jsonnet_ext = Extension(
     '_gojsonnet',
     sources=MODULE_SOURCES,
@@ -63,7 +68,7 @@ setup(name='gojsonnet',
     version=get_version(),
     cmdclass={
         'build_ext': BuildJsonnetExt,
+        'test': NoopTestCommand,
     },
     ext_modules=[jsonnet_ext],
-    test_suite="python._jsonnet_test",
 )

--- a/tests.sh
+++ b/tests.sh
@@ -14,8 +14,8 @@ then
 else
     c-bindings-tests/run.sh
 
-    $PYTHON_COMMAND setup.py build
-    pytest python
+    $PYTHON_COMMAND setup.py build --build-platlib .
+    $PYTHON_COMMAND -m pytest python
 fi
 
 export IMPLEMENTATION=golang

--- a/tests.sh
+++ b/tests.sh
@@ -15,7 +15,7 @@ else
     c-bindings-tests/run.sh
 
     $PYTHON_COMMAND setup.py build
-    $PYTHON_COMMAND setup.py test
+    pytest python
 fi
 
 export IMPLEMENTATION=golang


### PR DESCRIPTION
This resolves #369 

I decided to use `pytest` as a testing framework. It has some restrictions with python versions and I am not sure it is a good choice. Please let me know if my concerns are fair.

p.s. I manually disabled `setup.py test` command.