### PR TITLE
Remove bindings debug msg

### DIFF
--- a/c-bindings/c-bindings.go
+++ b/c-bindings/c-bindings.go
@@ -79,7 +79,6 @@ func (i *importer) Import(importedFrom, importedPath string) (contents jsonnet.C
 	if _, isCached := i.contentCache[foundHere]; !isCached {
 		i.contentCache[foundHere] = jsonnet.MakeContents(result)
 	}
-	fmt.Fprintf(os.Stderr, "%#+v\n", i.contentCache[foundHere])
 	return i.contentCache[foundHere], foundHere, nil
 }
 


### PR DESCRIPTION
Removing a rather noisy debug message in c-bindings which I believe was added for that purpose only and should have been deleted.