### PR TITLE
feat(api): expose formatter

### DIFF
--- a/cmd/jsonnetfmt/BUILD.bazel
+++ b/cmd/jsonnetfmt/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//:go_default_library",
-        "//cmd:go_default_library",
+        "//cmd/internal/cmd:go_default_library",
         "//internal/formatter:go_default_library",
         "@com_github_fatih_color//:go_default_library",
     ],

--- a/formatter/BUILD.bazel
+++ b/formatter/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["formatter.go"],
+    importpath = "github.com/google/go-jsonnet/formatter",
+    visibility = ["//visibility:public"],
+    deps = ["//internal/formatter:go_default_library"],
+)

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -1,0 +1,48 @@
+// Package formatter is what powers jsonnetfmt, a Jsonnet formatter.
+// It works similar to most other code formatters. Basically said, it takes the
+// contents of a file and returns them properly formatted. Behaviour can be
+// customized using formatter.Options.
+package formatter
+
+import "github.com/google/go-jsonnet/internal/formatter"
+
+// StringStyle controls how the reformatter rewrites string literals.
+// Strings that contain a ' or a " use the optimal syntax to avoid escaping
+// those characters.
+type StringStyle = formatter.StringStyle
+
+const (
+	// StringStyleDouble means "this".
+	StringStyleDouble StringStyle = iota
+	// StringStyleSingle means 'this'.
+	StringStyleSingle
+	// StringStyleLeave means strings are left how they were found.
+	StringStyleLeave
+)
+
+// CommentStyle controls how the reformatter rewrites comments.
+// Comments that look like a #! hashbang are always left alone.
+type CommentStyle = formatter.CommentStyle
+
+const (
+	// CommentStyleHash means #.
+	CommentStyleHash CommentStyle = iota
+	// CommentStyleSlash means //.
+	CommentStyleSlash
+	// CommentStyleLeave means comments are left as they are found.
+	CommentStyleLeave
+)
+
+// Options is a set of parameters that control the reformatter's behaviour.
+type Options = formatter.Options
+
+// DefaultOptions returns the recommended formatter behaviour.
+func DefaultOptions() Options {
+	return formatter.DefaultOptions()
+}
+
+// Format returns code that is equivalent to its input but better formatted
+// according to the given options.
+func Format(filename string, input string, options Options) (string, error) {
+	return formatter.Format(filename, input, options)
+}

--- a/internal/formatter/BUILD.bazel
+++ b/internal/formatter/BUILD.bazel
@@ -23,5 +23,6 @@ go_library(
     deps = [
         "//ast:go_default_library",
         "//internal/parser:go_default_library",
+        "//internal/pass:go_default_library",
     ],
 )


### PR DESCRIPTION
Exposes what I consider a good public API from the `internal/formatter`
package.

Having a go-native formatter is an awesome thing, especially because it
allows shipping the formatter as part of other projects. It's also fair
to keep the formatter's code in `internal`, yet third party projects
should have a way to use relevant parts of it.

**Note:** Ran `bazel run //:gazelle`, it modified other formatter related `BUILD.bazel` files as well ... is this expected?