### PR TITLE
fix order-dependent test

### DIFF
--- a/internal/dump/dump_test.go
+++ b/internal/dump/dump_test.go
@@ -447,8 +447,9 @@ var Obj = &struct { Foo *Zeo; Bar *Zeo }{
 		},
 	}
 	for _, test := range testcases {
-		Config.StripPackageNames = true
-		output := Sdump(test.input())
+		opts := Config
+		opts.StripPackageNames = true
+		output := opts.Sdump(test.input())
 		if test.expected != output {
 			t.Errorf("test case %s failed, expected : \n%#v\n, got : \n%#v", test.name, test.expected, output)
 		}
@@ -465,7 +466,7 @@ func TestSdumpLargeDefinition(t *testing.T) {
 	}
 	got := Sdump(&largeStruct{1, 2, 3, 4, 5})
 	want := `var Obj = _Obj
-var _Obj = &largeStruct{
+var _Obj = &dump.largeStruct{
 	ABCDEFGHIJKLMNOBQRSTUVWXYZ0: int(1),
 	ABCDEFGHIJKLMNOBQRSTUVWXYZ1: int(2),
 	ABCDEFGHIJKLMNOBQRSTUVWXYZ2: int(3),


### PR DESCRIPTION
TestSdumpLargeDefinition is depnding on a global state change made by TestSdumpReusedPointers. It can't pass if it runs before TestSdumpReusedPointers.

Fixes internal auto-filled bug.