### PR TITLE
Fix duplicated fodder (#411).

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -146,10 +146,10 @@ func (p *parser) parseArgument() (ast.Fodder, *ast.Identifier, ast.Fodder, ast.N
 func (p *parser) parseArguments(elementKind string) (*token, *ast.Arguments, bool, errors.StaticError) {
 	args := &ast.Arguments{}
 	gotComma := false
-	commaFodder := ast.Fodder{}
 	namedArgumentAdded := false
 	first := true
 	for {
+		commaFodder := ast.Fodder{}
 		next := p.peek()
 
 		if next.kind == tokenParenR {


### PR DESCRIPTION
CommaFodder was not cleared between arguments,
so when there was no commaFodder and the argument
was named a previous one was duplicated.

Fixes #411.