### PR TITLE
feat: Import post-processing

### DIFF
--- a/vm.go
+++ b/vm.go
@@ -31,14 +31,15 @@ import (
 // VM is the core interpreter and is the touchpoint used to parse and execute
 // Jsonnet.
 type VM struct {
-	MaxStack       int
-	ext            vmExtMap
-	tla            vmExtMap
-	nativeFuncs    map[string]*NativeFunction
-	importer       Importer
-	ErrorFormatter ErrorFormatter
-	StringOutput   bool
-	importCache    *importCache
+	MaxStack        int
+	ext             vmExtMap
+	tla             vmExtMap
+	nativeFuncs     map[string]*NativeFunction
+	importer        Importer
+	importProcessor ImportProcessor
+	ErrorFormatter  ErrorFormatter
+	StringOutput    bool
+	importCache     *importCache
 }
 
 // External variable or top level argument provided before execution
@@ -56,20 +57,21 @@ type vmExtMap map[string]vmExt
 func MakeVM() *VM {
 	defaultImporter := &FileImporter{}
 	return &VM{
-		MaxStack:       500,
-		ext:            make(vmExtMap),
-		tla:            make(vmExtMap),
-		nativeFuncs:    make(map[string]*NativeFunction),
-		ErrorFormatter: &termErrorFormatter{pretty: false, maxStackTraceSize: 20},
-		importer:       &FileImporter{},
-		importCache:    makeImportCache(defaultImporter),
+		MaxStack:        500,
+		ext:             make(vmExtMap),
+		tla:             make(vmExtMap),
+		nativeFuncs:     make(map[string]*NativeFunction),
+		ErrorFormatter:  &termErrorFormatter{pretty: false, maxStackTraceSize: 20},
+		importer:        &FileImporter{},
+		importProcessor: nil,
+		importCache:     makeImportCache(defaultImporter, nil),
 	}
 }
 
 // Fully flush cache. This should be executed when we are no longer sure that the source files
 // didn't change, for example when the importer changed.
 func (vm *VM) flushCache() {
-	vm.importCache = makeImportCache(vm.importer)
+	vm.importCache = makeImportCache(vm.importer, vm.importProcessor)
 }
 
 // Flush value cache. This should be executed when calculated values may no longer be up to date,
@@ -107,6 +109,13 @@ func (vm *VM) TLACode(key string, val string) {
 // Importer sets Importer to use during evaluation (import callback).
 func (vm *VM) Importer(i Importer) {
 	vm.importer = i
+	vm.flushCache()
+}
+
+// ImportProcessor sets the ImportProcesor to use during evaluation
+// (post-processing callback)
+func (vm *VM) ImportProcessor(i ImportProcessor) {
+	vm.importProcessor = i
 	vm.flushCache()
 }
 


### PR DESCRIPTION
Adds a second `interface` for importing, `ImportProcessor`. If set on a
VM (non-nil), it is asked to perhaps convert the Importer result before
importCache stores it.

This can for example be used to enhance what `import` is capable of, so
that it also reads `.yaml` files, etc.

This is a feature we once had in Tanka, but had to disable as we were
not able to differentiate between `import` and `importstr` based on the
`Importer` interface. This change allows us to do that, as
`ImportProcessor` is only ever considered for `import`.

https://github.com/grafana/tanka/issues/135#issuecomment-571228938