### PR TITLE
perf(stdlib): ⚡️  implement manifestJsonEx as native Go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,14 +43,14 @@ build:
 .PHONY: build
 
 build.old:
-	go build ./cmd/jsonnet -o jsonnet-old
+	go build -o jsonnet-old ./cmd/jsonnet
 .PHONY: build.old
 
 test:
 	./tests.sh
 .PHONY: test
 
-benchmark : FILTER="Builtin"
+benchmark : FILTER ?= Builtin
 benchmark: build
 	./benchmark.sh ${FILTER}
 .PHONY: benchmark

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Additionally if any files were moved around, see the section [Keeping the Bazel 
 
 ## Running Benchmarks
 
-Setup
+### Method 1
 
 ```bash
 go get golang.org/x/tools/cmd/benchcmp
@@ -88,6 +88,28 @@ go build ./cmd/jsonnet
 ```bash
 # e.g. ./benchmark.sh Builtin
 ./benchmark.sh <TestNameFilter>
+```
+
+### Method 2
+
+1. get `benchcmp`
+
+```bash
+go get golang.org/x/tools/cmd/benchcmp
+```
+
+2. Make sure you build a jsonnet binary _prior_ to making changes.
+
+```bash
+make build-old
+```
+
+3. iterate with (which will also automatically rebuild the new binary `./jsonnet`)
+
+_replace the FILTER with the name of the test you are working on_
+
+```bash
+FILTER=Builtin_manifestJsonEx make benchmark
 ```
 
 ## Implementation Notes

--- a/builtin-benchmarks/manifestJsonEx.jsonnet
+++ b/builtin-benchmarks/manifestJsonEx.jsonnet
@@ -1,0 +1,47 @@
+{
+  bar: {
+    prometheusOperator+: {
+      service+: {
+        spec+: {
+          ports: [
+            {
+              name: 'https',
+              port: 8443,
+              targetPort: 'https',
+            },
+          ],
+        },
+      },
+      serviceMonitor+: {
+        spec+: {
+          endpoints: [
+            {
+              port: 'https',
+              scheme: 'https',
+              honorLabels: true,
+              bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+              tlsConfig: {
+                insecureSkipVerify: true,
+              },
+            },
+          ]
+        },
+      },
+      clusterRole+: {
+        rules+: [
+          {
+            apiGroups: ['authentication.k8s.io'],
+            resources: ['tokenreviews'],
+            verbs: ['create'],
+          },
+          {
+            apiGroups: ['authorization.k8s.io'],
+            resources: ['subjectaccessreviews'],
+            verbs: ['create'],
+          },
+        ],
+      },
+    }
+  },
+  foo: std.manifestJsonEx(self.bar, "  ")
+}

--- a/builtins_benchmark_test.go
+++ b/builtins_benchmark_test.go
@@ -51,3 +51,7 @@ func Benchmark_Builtin_base64(b *testing.B) {
 func Benchmark_Builtin_base64_byte_array(b *testing.B) {
 	RunBenchmark(b, "base64_byte_array")
 }
+
+func Benchmark_Builtin_manifestJsonEx(b *testing.B) {
+	RunBenchmark(b, "manifestJsonEx")
+}


### PR DESCRIPTION
```
❯ make benchmark FILTER=Builtin_manifestJsonEx
go build ./cmd/jsonnet
./benchmark.sh Builtin_manifestJsonEx
Running Before Test... (10s)
Running After Test... (10s)
benchmark                               old ns/op     new ns/op     delta
Benchmark_Builtin_manifestJsonEx-16     22656394      7502016       -66.89%
```

---

EDIT
~I could use a small amount of help here. The test is currently failing seemingly because the output doesn't match. I suspect it's some sort of whitespace issue, but I can't tell.~

Fixed the problem, I was setting an initial indentation.