### PR TITLE
add remote import support

### DIFF
--- a/imports.go
+++ b/imports.go
@@ -214,16 +214,20 @@ func (importer *FileImporter) tryPath(dir, importedPath string) (found bool, con
 		entry = cacheEntry
 	} else {
 		if url.Scheme == "http" || url.Scheme == "https" {
-			resp, err := http.Get(absPath)
+			client := &http.Client{}
+			req, err := http.NewRequest("GET", absPath, nil)
+			req.Header.Add("Authorization", "token "+os.Getenv("GITHUB_TOKEN"))
+			req.Header.Add("Accept", "application/vnd.github.v3.raw")
+			resp, err := client.Do(req)
 			if err != nil {
-				fmt.Println("hey there was an error!")
 				fmt.Println(absPath)
 				fmt.Println(err)
-				panic(err)
+				return false, Contents{}, "", err
 			}
 			defer resp.Body.Close()
 
 			contentBytes, err := ioutil.ReadAll(resp.Body)
+
 			entry = &fsCacheEntry{
 				exists:   true,
 				contents: MakeContents(string(contentBytes)),

--- a/test.jsonnet
+++ b/test.jsonnet
@@ -1,3 +1,0 @@
-local K = import "https://github.com/bitnami-labs/kube-libsonnet/raw/52ba963ca44f7a4960aeae9ee0fbee44726e481f/kube.libsonnet";
-
-K.PersistentVolume('whaaat')

--- a/test.jsonnet
+++ b/test.jsonnet
@@ -1,0 +1,3 @@
+local K = import "https://github.com/bitnami-labs/kube-libsonnet/raw/52ba963ca44f7a4960aeae9ee0fbee44726e481f/kube.libsonnet";
+
+K.PersistentVolume('whaaat')


### PR DESCRIPTION
quick and dirty implementation of adding support for resolving imports over HTTP/S. My use case is to resolve Jsonnet libraries from private, internal GitHub repos. I've added support for authentication over HTTP but this has made it unfortunately very GitHub-specific. Alternatively, this could be refactored to use `git` (via [go-git](https://github.com/go-git/go-git/)) to be more generic.

Looking for initial feedback on (a) whether the maintainers support this idea _conceptually_ and (b) if the maintainers prefer a specific resolution mechanism (HTTP vs git vs other) before taking this further.

### Notes

* Since it is an extension of `FileImporter`, this also
  * supports resolving transitive dependencies _assuming they are also defined as remote_. If `https://domain.com/foo.libsonnet` imports `./bar.libsonnet`, Jsonnet will crash when trying to resolve `./bar.libsonnet` because it doesn't exist at that local path. However if `https://domain.com/foo.libsonnet` imports `https://domain.com/bar.libsonnet`, then it works
  * caches the results, avoiding fetching the same import multiple times
* Needs better error handling - failing to resolve a remote import results in mis-leading Jsonnet errors like `Field does not exist`
* Current implementation requires `GITHUB_TOKEN` env var set for all requests (even for public repos) since we're using the GitHub API to fetch contents
* Feature request outlined in #432 

### Example

```jsonnet
// Browsable URL - https://github.com/grafana/grafonnet-lib/blob/master/grafonnet/prometheus.libsonnet
local prometheus = import "https://api.github.com/repos/grafana/grafonnet-lib/contents/grafonnet/prometheus.libsonnet";

prometheus.target(expr='foo')
```
produces
```
{
   "expr": "foo",
   "format": "time_series",
   "intervalFactor": 2,
   "legendFormat": ""
}
```