### PR TITLE
Add github action to build binaries with goreleaser.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+# build binaries and add to release - see
+# https://github.com/goreleaser/goreleaser-action
+
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,53 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - 386
+      - amd64
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+      - goarch: 386
+
+    id: jsonnet
+    main: ./cmd/jsonnet
+    binary: jsonnet
+
+  # goreleaser complains about unexpected keys, so there's nowhere to hang an
+  # anchor, so we have to repeat the common elements :(
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - 386
+      - amd64
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+      - goarch: 386
+
+    id: jsonnetfmt
+    main: ./cmd/jsonnetfmt
+    binary: jsonnetfmt
+
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'


### PR DESCRIPTION
This add a github action to build binaries and add them as release artefacts using goreleaser (https://goreleaser.com/).

It seems to work fine - see e.g. https://github.com/PaulRudin/go-jsonnet/releases/tag/v0.0.200. I've checked that the binaries for linux amd64 work.
