### PR TITLE
Anonymous Import Locations

### DIFF
--- a/c-bindings/c-bindings.go
+++ b/c-bindings/c-bindings.go
@@ -139,6 +139,8 @@ func getVM(vmRef *C.struct_JsonnetVm) *vm {
 
 func evaluateSnippet(vmRef *C.struct_JsonnetVm, filename string, code string, e *C.int) *C.char {
 	vm := getVM(vmRef)
+	// We still use a deprecated function to keep backwards compatible behavior.
+	//nolint:staticcheck
 	out, err := vm.EvaluateSnippet(filename, code)
 	var result *C.char
 	if err != nil {

--- a/cmd/dumpstdlibast/BUILD.bazel
+++ b/cmd/dumpstdlibast/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/google/go-jsonnet/cmd/dumpstdlibast",
     visibility = ["//visibility:private"],
     deps = [
+        "//ast:go_default_library",
         "//internal/dump:go_default_library",
         "//internal/program:go_default_library",
     ],

--- a/cmd/dumpstdlibast/dumpstdlibast.go
+++ b/cmd/dumpstdlibast/dumpstdlibast.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/google/go-jsonnet/ast"
 	"github.com/google/go-jsonnet/internal/dump"
 	"github.com/google/go-jsonnet/internal/program"
 )
@@ -33,7 +34,7 @@ func main() {
 		panic(err)
 	}
 
-	node, err := program.SnippetToAST("<std>", string(buf))
+	node, err := program.SnippetToAST(ast.DiagnosticFileName("<std>"), "", string(buf))
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/jsonnet/cmd.go
+++ b/cmd/jsonnet/cmd.go
@@ -447,16 +447,27 @@ func main() {
 		panic("Internal error: expected a single input file.")
 	}
 	filename := config.inputFiles[0]
+	// TODO(sbarzowski) Clean up SafeReadInput to be more in line with the new API
 	input := cmd.SafeReadInput(config.filenameIsCode, &filename)
 	var output string
 	var outputArray []string
 	var outputDict map[string]string
-	if config.evalMulti {
-		outputDict, err = vm.EvaluateSnippetMulti(filename, input)
-	} else if config.evalStream {
-		outputArray, err = vm.EvaluateSnippetStream(filename, input)
+	if config.filenameIsCode || config.inputFiles[0] == "-" {
+		if config.evalMulti {
+			outputDict, err = vm.EvaluateAnonymousSnippetMulti(filename, input)
+		} else if config.evalStream {
+			outputArray, err = vm.EvaluateAnonymousSnippetStream(filename, input)
+		} else {
+			output, err = vm.EvaluateAnonymousSnippet(filename, input)
+		}
 	} else {
-		output, err = vm.EvaluateSnippet(filename, input)
+		if config.evalMulti {
+			outputDict, err = vm.EvaluateFileMulti(filename)
+		} else if config.evalStream {
+			outputArray, err = vm.EvaluateFileStream(filename)
+		} else {
+			output, err = vm.EvaluateFile(filename)
+		}
 	}
 
 	cmd.MemProfile()

--- a/internal/formatter/jsonnetfmt.go
+++ b/internal/formatter/jsonnetfmt.go
@@ -136,7 +136,7 @@ func visitFile(p pass.ASTPass, node *ast.Node, finalFodder *ast.Fodder) {
 // Format returns code that is equivalent to its input but better formatted
 // according to the given options.
 func Format(filename string, input string, options Options) (string, error) {
-	node, finalFodder, err := parser.SnippetToRawAST(filename, input)
+	node, finalFodder, err := parser.SnippetToRawAST(ast.DiagnosticFileName(filename), "", input)
 	if err != nil {
 		return "", err
 	}

--- a/internal/parser/lexer_test.go
+++ b/internal/parser/lexer_test.go
@@ -82,7 +82,7 @@ func SingleTest(t *testing.T, input string, expectedError string, expected Token
 	if len(testTokens) == 0 || testTokens[len(testTokens)-1].kind != tokenEndOfFile {
 		testTokens = append(testTokens, tEOF)
 	}
-	tokens, err := Lex("snippet", input)
+	tokens, err := Lex("snippet", "", input)
 	var errString string
 	if err != nil {
 		errString = err.Error()

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1384,8 +1384,8 @@ func Parse(t Tokens) (ast.Node, ast.Fodder, errors.StaticError) {
 
 // SnippetToRawAST converts a Jsonnet code snippet to an AST (without any transformations).
 // Any fodder after the final token is returned as well.
-func SnippetToRawAST(filename string, snippet string) (ast.Node, ast.Fodder, error) {
-	tokens, err := Lex(filename, snippet)
+func SnippetToRawAST(diagnosticFilename ast.DiagnosticFileName, importedFilename, snippet string) (ast.Node, ast.Fodder, error) {
+	tokens, err := Lex(diagnosticFilename, importedFilename, snippet)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -126,7 +126,7 @@ var tests = []string{
 func TestParser(t *testing.T) {
 	for _, s := range tests {
 		t.Run(s, func(t *testing.T) {
-			tokens, err := Lex("test", s)
+			tokens, err := Lex("test", "", s)
 			if err != nil {
 				t.Errorf("Unexpected lex error\n  input: %v\n  error: %v", s, err)
 				return
@@ -250,7 +250,7 @@ var errorTests = []testError{
 func TestParserErrors(t *testing.T) {
 	for _, s := range errorTests {
 		t.Run(s.input, func(t *testing.T) {
-			tokens, err := Lex("test", s.input)
+			tokens, err := Lex("test", "", s.input)
 			if err != nil {
 				t.Errorf("Unexpected lex error\n  input: %v\n  error: %v", s.input, err)
 				return

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -6,8 +6,8 @@ import (
 )
 
 // SnippetToAST converts a Jsonnet code snippet to a desugared and analyzed AST.
-func SnippetToAST(filename string, snippet string) (ast.Node, error) {
-	node, _, err := parser.SnippetToRawAST(filename, snippet)
+func SnippetToAST(diagnosticFilename ast.DiagnosticFileName, importedFilename, snippet string) (ast.Node, error) {
+	node, _, err := parser.SnippetToRawAST(diagnosticFilename, importedFilename, snippet)
 	if err != nil {
 		return nil, err
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -137,7 +137,7 @@ func runInternalJsonnet(i jsonnetInput) jsonnetResult {
 	vm.NativeFunction(jsonToString)
 	vm.NativeFunction(nativeError)
 
-	rawAST, _, staticErr := parser.SnippetToRawAST(i.name, string(i.input))
+	rawAST, _, staticErr := parser.SnippetToRawAST(ast.DiagnosticFileName(i.name), "", string(i.input))
 	if staticErr != nil {
 		return jsonnetResult{
 			output:  errFormatter.Format(staticErr) + "\n",
@@ -155,7 +155,8 @@ func runInternalJsonnet(i jsonnetInput) jsonnetResult {
 	}
 	testChildren(desugaredAST)
 
-	rawOutput, err := vm.evaluateSnippet(i.name, string(i.input), i.eKind)
+	// TODO(sbarzowski) We should treat the tests as anonymous snippets or import them with an importer.
+	rawOutput, err := vm.evaluateSnippet(ast.DiagnosticFileName(i.name), i.name, string(i.input), i.eKind)
 	switch {
 	case err != nil:
 		// TODO(sbarzowski) perhaps somehow mark that we are processing

--- a/vm.go
+++ b/vm.go
@@ -146,7 +146,7 @@ func (vm *VM) Evaluate(node ast.Node) (val string, err error) {
 
 // EvaluateStream evaluates a Jsonnet program given by an Abstract Syntax Tree
 // and returns an array of JSON strings.
-func (vm *VM) EvaluateStream(node ast.Node) (output interface{}, err error) {
+func (vm *VM) EvaluateStream(node ast.Node) (output []string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("(CRASH) %v\n%s", r, debug.Stack())
@@ -158,7 +158,7 @@ func (vm *VM) EvaluateStream(node ast.Node) (output interface{}, err error) {
 // EvaluateMulti evaluates a Jsonnet program given by an Abstract Syntax Tree
 // and returns key-value pairs.
 // The keys are strings and the values are JSON strigns (serialized JSON).
-func (vm *VM) EvaluateMulti(node ast.Node) (output interface{}, err error) {
+func (vm *VM) EvaluateMulti(node ast.Node) (output map[string]string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("(CRASH) %v\n%s", r, debug.Stack())
@@ -167,13 +167,13 @@ func (vm *VM) EvaluateMulti(node ast.Node) (output interface{}, err error) {
 	return evaluateMulti(node, vm.ext, vm.tla, vm.nativeFuncs, vm.MaxStack, vm.importCache, vm.StringOutput)
 }
 
-func (vm *VM) evaluateSnippet(filename string, snippet string, kind evalKind) (output interface{}, err error) {
+func (vm *VM) evaluateSnippet(diagnosticFileName ast.DiagnosticFileName, filename string, snippet string, kind evalKind) (output interface{}, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("(CRASH) %v\n%s", r, debug.Stack())
 		}
 	}()
-	node, err := SnippetToAST(filename, snippet)
+	node, err := program.SnippetToAST(diagnosticFileName, filename, snippet)
 	if err != nil {
 		return "", err
 	}
@@ -265,9 +265,11 @@ func (vm *VM) findDependencies(filePath string, node *ast.Node, dependencies map
 // EvaluateSnippet evaluates a string containing Jsonnet code, return a JSON
 // string.
 //
-// The filename parameter is only used for error messages.
+// The filename parameter is used for resolving relative imports and for errors messages.
+//
+// Deprecated: Use EvaluateFile or EvaluateAnonymousSnippet instead.
 func (vm *VM) EvaluateSnippet(filename string, snippet string) (json string, formattedErr error) {
-	output, err := vm.evaluateSnippet(filename, snippet, evalKindRegular)
+	output, err := vm.evaluateSnippet(ast.DiagnosticFileName(filename), filename, snippet, evalKindRegular)
 	if err != nil {
 		return "", errors.New(vm.ErrorFormatter.Format(err))
 	}
@@ -278,9 +280,11 @@ func (vm *VM) EvaluateSnippet(filename string, snippet string) (json string, for
 // EvaluateSnippetStream evaluates a string containing Jsonnet code to an array.
 // The array is returned as an array of JSON strings.
 //
-// The filename parameter is only used for error messages.
+// The filename parameter is used for resolving relative imports and for errors messages.
+//
+// Deprecated: Use EvaluateFileStream or EvaluateAnonymousSnippetStream instead.
 func (vm *VM) EvaluateSnippetStream(filename string, snippet string) (docs []string, formattedErr error) {
-	output, err := vm.evaluateSnippet(filename, snippet, evalKindStream)
+	output, err := vm.evaluateSnippet(ast.DiagnosticFileName(filename), filename, snippet, evalKindStream)
 	if err != nil {
 		return nil, errors.New(vm.ErrorFormatter.Format(err))
 	}
@@ -291,14 +295,103 @@ func (vm *VM) EvaluateSnippetStream(filename string, snippet string) (docs []str
 // EvaluateSnippetMulti evaluates a string containing Jsonnet code to key-value
 // pairs. The keys are field name strings and the values are JSON strings.
 //
-// The filename parameter is only used for error messages.
+// The filename parameter is used for resolving relative imports and for errors messages.
+//
+// Deprecated: Use EvaluateFileMulti or EvaluateAnonymousSnippetMulti instead.
 func (vm *VM) EvaluateSnippetMulti(filename string, snippet string) (files map[string]string, formattedErr error) {
-	output, err := vm.evaluateSnippet(filename, snippet, evalKindMulti)
+	output, err := vm.evaluateSnippet(ast.DiagnosticFileName(filename), filename, snippet, evalKindMulti)
 	if err != nil {
 		return nil, errors.New(vm.ErrorFormatter.Format(err))
 	}
 	files = output.(map[string]string)
 	return
+}
+
+// EvaluateAnonymousSnippet evaluates a string containing Jsonnet code, return a JSON
+// string.
+//
+// The filename parameter is only used for error messages.
+func (vm *VM) EvaluateAnonymousSnippet(filename string, snippet string) (json string, formattedErr error) {
+	output, err := vm.evaluateSnippet(ast.DiagnosticFileName(filename), "", snippet, evalKindRegular)
+	if err != nil {
+		return "", errors.New(vm.ErrorFormatter.Format(err))
+	}
+	json = output.(string)
+	return
+}
+
+// EvaluateAnonymousSnippetStream evaluates a string containing Jsonnet code to an array.
+// The array is returned as an array of JSON strings.
+//
+// The filename parameter is only used for error messages.
+func (vm *VM) EvaluateAnonymousSnippetStream(filename string, snippet string) (docs []string, formattedErr error) {
+	output, err := vm.evaluateSnippet(ast.DiagnosticFileName(filename), "", snippet, evalKindStream)
+	if err != nil {
+		return nil, errors.New(vm.ErrorFormatter.Format(err))
+	}
+	docs = output.([]string)
+	return
+}
+
+// EvaluateAnonymousSnippetMulti evaluates a string containing Jsonnet code to key-value
+// pairs. The keys are field name strings and the values are JSON strings.
+//
+// The filename parameter is only used for error messages.
+func (vm *VM) EvaluateAnonymousSnippetMulti(filename string, snippet string) (files map[string]string, formattedErr error) {
+	output, err := vm.evaluateSnippet(ast.DiagnosticFileName(filename), "", snippet, evalKindMulti)
+	if err != nil {
+		return nil, errors.New(vm.ErrorFormatter.Format(err))
+	}
+	files = output.(map[string]string)
+	return
+}
+
+// EvaluateFile evaluates Jsonnet code in a file and returns a JSON
+// string.
+//
+// The importer is used to fetch the contents of the file.
+func (vm *VM) EvaluateFile(filename string) (json string, formattedErr error) {
+	node, _, err := vm.ImportAST("", filename)
+	if err != nil {
+		return "", errors.New(vm.ErrorFormatter.Format(err))
+	}
+	output, err := vm.Evaluate(node)
+	if err != nil {
+		return "", errors.New(vm.ErrorFormatter.Format(err))
+	}
+	return output, nil
+}
+
+// EvaluateFileStream evaluates Jsonnet code in a file to an array.
+// The array is returned as an array of JSON strings.
+//
+// The importer is used to fetch the contents of the file.
+func (vm *VM) EvaluateFileStream(filename string) (docs []string, formattedErr error) {
+	node, _, err := vm.ImportAST("", filename)
+	if err != nil {
+		return nil, errors.New(vm.ErrorFormatter.Format(err))
+	}
+	output, err := vm.EvaluateStream(node)
+	if err != nil {
+		return nil, errors.New(vm.ErrorFormatter.Format(err))
+	}
+	return output, nil
+}
+
+// EvaluateFileMulti evaluates Jsonnet code in a file to key-value
+// pairs. The keys are field name strings and the values are JSON strings.
+//
+// The importer is used to fetch the contents of the file.
+func (vm *VM) EvaluateFileMulti(filename string) (files map[string]string, formattedErr error) {
+	node, _, err := vm.ImportAST("", filename)
+	if err != nil {
+		return nil, errors.New(vm.ErrorFormatter.Format(err))
+	}
+	output, err := vm.EvaluateMulti(node)
+	if err != nil {
+		return nil, errors.New(vm.ErrorFormatter.Format(err))
+	}
+	return output, nil
 }
 
 // FindDependencies returns a sorted array of unique transitive dependencies (via import or importstr)
@@ -381,7 +474,7 @@ func (vm *VM) ImportAST(importedFrom, importedPath string) (contents ast.Node, f
 
 // SnippetToAST parses a snippet and returns the resulting AST.
 func SnippetToAST(filename string, snippet string) (ast.Node, error) {
-	return program.SnippetToAST(filename, snippet)
+	return program.SnippetToAST(ast.DiagnosticFileName(filename), filename, snippet)
 }
 
 // Version returns the Jsonnet version number.


### PR DESCRIPTION
We used to treat dummy paths like `<stdin>`, `<std>`, `<extvar>` as
real import locations, which causes obvious problem for importers.

After this change we consistently pass "" (an empty string) as location
for non-imported paths.

We exposed new functions to properly handle all paths.

The first function family, EvaluateFile*  allows evaluating
a Jsonnet program at a specified importable path. It should
be used in most cases.

The second function family, EvaluateAnonymousSnippet* allows evaluating
a snippet without an importable path. It should be used for situations
like the code passed as a commandline argument, stdin, etc.

The old function family, EvaluateSnippet* is now deprecated, but
works the same as before, i.e. the passed filenames are treated
as imported paths.

Changes are required to custom importers to make sure they satisfy
the refined contract.

Fixes #329.