### PR TITLE
Using cpp_jsonnet as external repo

### DIFF
--- a/astgen/BUILD.bazel
+++ b/astgen/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 genrule(
     name = "dumpstdlibast",
-    srcs = ["//cpp-jsonnet/stdlib"],
+    srcs = ["@cpp_jsonnet//stdlib"],
     outs = ["stdast.go"],
     cmd = "./$(location //cmd/dumpstdlibast) \"$<\" > \"$@\"",
     tools = ["//cmd/dumpstdlibast"],

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -29,3 +29,10 @@ def jsonnet_go_repositories():
         strip_prefix = "bazel-gazelle-38bd65ead186af23549480d6189b89c7c53c023e",
         urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/38bd65ead186af23549480d6189b89c7c53c023e.zip"],
     )
+    _maybe(
+        http_archive,
+        name = "cpp_jsonnet",
+        sha256 = "fa1a4047942797b7c4ed39718a20d63d1b98725fb5cf563efbc1ecca3375426f",
+        strip_prefix = "jsonnet-0.16.0",
+        urls = ["https://github.com/google/jsonnet/archive/v0.16.0.tar.gz"],
+    )

--- a/c-bindings/BUILD.bazel
+++ b/c-bindings/BUILD.bazel
@@ -18,7 +18,7 @@ go_library(
         "libjsonnet.cpp",
     ],
     cdeps = [
-        "//cpp-jsonnet/include:libjsonnet",
+        "@cpp_jsonnet//include:libjsonnet",
     ],
     cgo = True,
     copts = ["-Wall -Icpp-jsonnet/include"],  # keep


### PR DESCRIPTION
This PR add cpp_jsonnet as an `http_archive` rule and refer it as an external repo in Bazel rules. This is the more natural way of referring other repositories on Bazel, and is an alternative way to fix #375. Comparing to the `git_repository` approach, this allows other repositories to use go-jsonnet as a `go_repository` and use `gazelle update-repos` to import it from the `go.mod` file, which fixes #392.

TODO: either set up a CI check to make sure the submodule has the same version as the one downloaded by `http_archive`, or remove the git submodule if nothing else is using it.