### PR TITLE
Add debian package build to goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,3 +51,37 @@ archives:
       amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
+
+nfpms:
+  - id: jsonnet
+    package_name: jsonnet-go
+    builds:
+      - jsonnet
+    description: A data templating language for app and tool developers
+    homepage: https://github.com/google/go-jsonnet
+    license: Apache 2.0
+    formats:
+      - deb
+    bindir: /usr/bin
+    maintainer: David Cunningham <dcunnin@google.com>
+    file_name_template: "jsonnet-go_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    overrides:
+      deb:
+        conflicts:
+          # See: https://packages.ubuntu.com/jsonnet
+          - jsonnet
+  - id: jsonnetfmt
+    package_name: jsonnetfmt-go
+    builds:
+      - jsonnetfmt
+    homepage: https://github.com/google/go-jsonnet
+    license: Apache 2.0
+    formats:
+      - deb
+    bindir: /usr/bin
+    file_name_template: "jsonnetfmt-go_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    overrides:
+      deb:
+        conflicts:
+          # See: https://packages.ubuntu.com/jsonnet
+          - jsonnetfmt


### PR DESCRIPTION
This makes the goreleaser output two debian packages. One for jsonnet,
and another for jsonnetfmt. Since we don't use cgo, we don't need to
take dependencies, as we're fully statically linked. The package
name for this package will be go-jsonnet, and go-jsonnetfmt. There
is a package that Ubuntu has released that's based on the C++
version. We have a conflict statement with it in order to
avoid people installing both.

    We can ask the C++ package to rename itself to jsonnet-c++, and then
    add a provides for the package name jsonnet. The reason to not name
    this jsonnet immediately, even though the Go version if meant to
    supercede the C++ version, is that this doesn't fully implement the
    C++ version (for example, man pages).
