### PR TITLE
Remove dependency on cpp-jsonnet submodule from C bindings

### DIFF
--- a/c-bindings/BUILD.bazel
+++ b/c-bindings/BUILD.bazel
@@ -17,12 +17,9 @@ go_library(
         "internal.h",
         "libjsonnet.cpp",
     ],
-    cdeps = [
-        "@cpp_jsonnet//include:libjsonnet",
-    ],
     cgo = True,
-    copts = ["-Wall -Icpp-jsonnet/include"],  # keep
-    cxxopts = ["-std=c++11 -Wall -Icpp-jsonnet/include"],
+    copts = ["-Wall"],  # keep
+    cxxopts = ["-std=c++11 -Wall"],
     importpath = "github.com/google/go-jsonnet/c-bindings",
     visibility = ["//visibility:private"],
     deps = [

--- a/c-bindings/c-bindings.go
+++ b/c-bindings/c-bindings.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-jsonnet/ast"
 	"github.com/google/go-jsonnet/formatter"
 
-	// #cgo CXXFLAGS: -std=c++11 -Wall -I../cpp-jsonnet/include
+	// #cgo CXXFLAGS: -std=c++11 -Wall
 	// #include "internal.h"
 	"C"
 )

--- a/c-bindings/libjsonnet.cpp
+++ b/c-bindings/libjsonnet.cpp
@@ -2,7 +2,10 @@
 #include <stdlib.h>
 
 extern "C" {
-    #include "libjsonnet.h"
+    void jsonnet_gc_min_objects(struct JsonnetVm *vm, unsigned v);
+    void jsonnet_gc_growth_trigger(struct JsonnetVm *vm, double v);
+    char *jsonnet_realloc(JsonnetVm *vm, char *str, size_t sz);
+
     #include "internal.h"
 }
 


### PR DESCRIPTION
This change allows us to build libgojsonnet from tarball downloaded from
GitHub releases.