### PR TITLE
Fix builds filter ro re-enable darwin builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,7 +36,7 @@ builds:
       - arm64
     ignore:
       - goos: darwin
-      - goarch: 386
+        goarch: 386
 
     id: jsonnetfmt
     main: ./cmd/jsonnetfmt


### PR DESCRIPTION
I was not able to find any evidences of darwin builds being disabled intentionally. Considering
the [documentation](https://goreleaser.com/customization/build/) I suspect that this was by
mistake. Currently, each list item is applied individually (OR). If I'm wrong, please discard this
PR and share your reasoning.