### PR TITLE
sketch: allow initialization of external and TLA code variables from an AST node

### DIFF
--- a/imports.go
+++ b/imports.go
@@ -139,6 +139,15 @@ func (cache *importCache) importString(importedFrom, importedPath string, i *int
 	return makeValueString(data.String()), nil
 }
 
+func nodeToPV(i *interpreter, filename string, node ast.Node) *cachedThunk {
+	env := makeInitialEnv(filename, i.baseStd)
+	return &cachedThunk{
+		env:     &env,
+		body:    node,
+		content: nil,
+	}
+}
+
 func codeToPV(i *interpreter, filename string, code string) *cachedThunk {
 	node, err := program.SnippetToAST(ast.DiagnosticFileName(filename), "", code)
 	if err != nil {
@@ -149,12 +158,7 @@ func codeToPV(i *interpreter, filename string, code string) *cachedThunk {
 		// The same thinking applies to external variables.
 		return &cachedThunk{err: err}
 	}
-	env := makeInitialEnv(filename, i.baseStd)
-	return &cachedThunk{
-		env:     &env,
-		body:    node,
-		content: nil,
-	}
+	return nodeToPV(i, filename, node)
 }
 
 // ImportCode imports code from a path.

--- a/interpreter.go
+++ b/interpreter.go
@@ -1195,7 +1195,12 @@ func prepareExtVars(i *interpreter, ext vmExtMap, kind string) map[string]*cache
 	result := make(map[string]*cachedThunk)
 	for name, content := range ext {
 		if content.isCode {
-			result[name] = codeToPV(i, "<"+kind+":"+name+">", content.value)
+			filename := "<" + kind + ":" + name + ">"
+			if content.isNode {
+				result[name] = nodeToPV(i, filename, content.node)
+			} else {
+				result[name] = codeToPV(i, filename, content.value)
+			}
 		} else {
 			result[name] = readyThunk(makeValueString(content.value))
 		}

--- a/vm.go
+++ b/vm.go
@@ -53,6 +53,11 @@ type vmExt struct {
 	// isCode determines whether it should be evaluated as jsonnet code or
 	// treated as string.
 	isCode bool
+	// an ext or TLS code variable can also be initialized from an AST node
+	node ast.Node
+	// isNode determines if a code variable has been initialized using an AST node
+	// as opposed to a code string.
+	isNode bool
 }
 
 type vmExtMap map[string]vmExt
@@ -95,6 +100,12 @@ func (vm *VM) ExtCode(key string, val string) {
 	vm.flushValueCache()
 }
 
+// ExtCodeNode binds a Jsonnet external code var to the given AST node.
+func (vm *VM) ExtCodeNode(key string, node ast.Node) {
+	vm.ext[key] = vmExt{node: node, isCode: true, isNode: true}
+	vm.flushValueCache()
+}
+
 // TLAVar binds a Jsonnet top level argument to the given value.
 func (vm *VM) TLAVar(key string, val string) {
 	vm.tla[key] = vmExt{value: val, isCode: false}
@@ -106,6 +117,12 @@ func (vm *VM) TLAVar(key string, val string) {
 // TLACode binds a Jsonnet top level argument to the given code.
 func (vm *VM) TLACode(key string, val string) {
 	vm.tla[key] = vmExt{value: val, isCode: true}
+	// Setting a TLA does not require flushing the cache - see above.
+}
+
+// TLACodeNode binds a Jsonnet top level argument to the given AST node.
+func (vm *VM) TLACodeNode(key string, node ast.Node) {
+	vm.tla[key] = vmExt{node: node, isCode: true, isNode: true}
 	// Setting a TLA does not require flushing the cache - see above.
 }
 


### PR DESCRIPTION
This allows configuration of a VM with an external code variable that has been pre-parsed into an AST node.
This allows a caller to pre-parse a large object into a node and re-use that for multiple VMs. The cost
of converting the object to an `ast.Node` is incurred only once by the caller as opposed to having this
eagerly incurred (whether or not the object is used) before the eval.

If the implementation looks acceptable, I'll add the tests.