### PR TITLE
Make jsonnetfmt add plus objects instead of removing them

### DIFF
--- a/cmd/jsonnetfmt/cmd.go
+++ b/cmd/jsonnetfmt/cmd.go
@@ -58,6 +58,8 @@ func usage(o io.Writer) {
 	fmt.Fprintln(o, "  --[no-]pad-objects         { x: 1, y: 2 } instead of {x: 1, y: 2}")
 	fmt.Fprintln(o, "                             (on by default)")
 	fmt.Fprintln(o, "  --[no-]sort-imports        Sorting of imports (on by default)")
+	fmt.Fprintln(o, "  --[no-]use-implicit-plus   Remove plus signs where they are not required")
+	fmt.Fprintln(o, "                             (on by default)")
 	fmt.Fprintln(o, "  --version                  Print version")
 	fmt.Fprintln(o)
 	fmt.Fprintln(o, "In all cases:")
@@ -161,6 +163,10 @@ func processArgs(givenArgs []string, config *config, vm *jsonnet.VM) (processArg
 			default:
 				return processArgsStatusFailure, fmt.Errorf("invalid --comment-style value: %s", str)
 			}
+		} else if arg == "--use-implicit-plus" {
+			config.options.UseImplicitPlus = true
+		} else if arg == "--no-use-implicit-plus" {
+			config.options.UseImplicitPlus = false
 		} else if arg == "--pretty-field-names" {
 			config.options.PrettyFieldNames = true
 		} else if arg == "--no-pretty-field-names" {

--- a/internal/formatter/add_plus_object.go
+++ b/internal/formatter/add_plus_object.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2019 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package formatter
+
+import (
+	"github.com/google/go-jsonnet/ast"
+	"github.com/google/go-jsonnet/internal/pass"
+)
+
+// AddPlusObject is a formatter pass that replaces e {} with e + {}.
+type AddPlusObject struct {
+	pass.Base
+}
+
+// Visit replaces ApplyBrace with Binary node.
+func (c *AddPlusObject) Visit(p pass.ASTPass, node *ast.Node, ctx pass.Context) {
+	applyBrace, ok := (*node).(*ast.ApplyBrace)
+	if ok {
+		*node = &ast.Binary{
+			NodeBase: applyBrace.NodeBase,
+			Left:     applyBrace.Left,
+			Op:       ast.BopPlus,
+			Right:    applyBrace.Right,
+		}
+	}
+	c.Base.Visit(p, node, ctx)
+}

--- a/internal/formatter/jsonnetfmt.go
+++ b/internal/formatter/jsonnetfmt.go
@@ -66,6 +66,8 @@ type Options struct {
 	// SortImports causes imports at the top of the file to be sorted in groups
 	// by filename.
 	SortImports bool
+	// UseImplicitPlus removes plus sign where it is not required.
+	UseImplicitPlus bool
 
 	StripEverything     bool
 	StripComments       bool
@@ -79,6 +81,7 @@ func DefaultOptions() Options {
 		MaxBlankLines:    2,
 		StringStyle:      StringStyleSingle,
 		CommentStyle:     CommentStyleSlash,
+		UseImplicitPlus:  true,
 		PrettyFieldNames: true,
 		PadArrays:        false,
 		PadObjects:       true,
@@ -152,7 +155,11 @@ func Format(filename string, input string, options Options) (string, error) {
 	visitFile(&FixNewlines{}, &node, &finalFodder)
 	visitFile(&FixTrailingCommas{}, &node, &finalFodder)
 	visitFile(&FixParens{}, &node, &finalFodder)
-	visitFile(&FixPlusObject{}, &node, &finalFodder)
+	if options.UseImplicitPlus {
+		visitFile(&RemovePlusObject{}, &node, &finalFodder)
+	} else {
+		visitFile(&AddPlusObject{}, &node, &finalFodder)
+	}
 	visitFile(&NoRedundantSliceColon{}, &node, &finalFodder)
 	if options.StripComments {
 		visitFile(&StripComments{}, &node, &finalFodder)


### PR DESCRIPTION
Implements: https://github.com/google/go-jsonnet/issues/496

- I reused the `fix_plus_sign.go` file instead of removing it and creating a new one. Let me know if you would like rename it.
- I don't add new `Fodder` nor interact with existing `Fodder` in any way. I think that is correct but that's for someone more knowledgeable to say.
- I'm not sure if the comments are correct so please check them.