### PR TITLE
pre-commit hook to format jsonnet files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+# How to use pre-commit hook: https://pre-commit.com
+- id: jsonnet-format
+  name: Format fix for jsonnet/libsonnet files
+  entry: jsonnetfmt -i
+  language: golang
+  files: '\.(jsonnet|libsonnet)$'
+  additional_dependencies: [ "github.com/google/go-jsonnet/cmd/jsonnetfmt" ]


### PR DESCRIPTION
Once this is merged, we can update https://pre-commit.com/hooks page for users to use this hook.