### PR TITLE
Allow setting a different output stream than os.Stderr for std.trace

### DIFF
--- a/builtins.go
+++ b/builtins.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -251,7 +250,7 @@ func builtinTrace(i *interpreter, x value, y value) (value, error) {
 	filename := trace.loc.FileName
 	line := trace.loc.Begin.Line
 	fmt.Fprintf(
-		os.Stderr, "TRACE: %s:%d %s\n", filename, line, xStr.getGoString())
+		i.traceOut, "TRACE: %s:%d %s\n", filename, line, xStr.getGoString())
 	return y, nil
 }
 

--- a/builtins.go
+++ b/builtins.go
@@ -247,7 +247,7 @@ func builtinTrace(i *interpreter, x value, y value) (value, error) {
 		return nil, err
 	}
 	trace := i.stack.currentTrace
-	filename := trace.loc.FileName
+	filename := trace.loc.File.DiagnosticFileName
 	line := trace.loc.Begin.Line
 	fmt.Fprintf(
 		i.traceOut, "TRACE: %s:%d %s\n", filename, line, xStr.getGoString())

--- a/jsonnet_test.go
+++ b/jsonnet_test.go
@@ -3,6 +3,7 @@ package jsonnet
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -326,4 +327,24 @@ func TestTLATypes(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	assertVarOutput(t, jsonStr)
+}
+
+func TestSetTraceOut(t *testing.T) {
+	traceOut := &strings.Builder{}
+	vm := MakeVM()
+	vm.SetTraceOut(traceOut)
+
+	const msg = "Some Trace Message"
+	expected := fmt.Sprintf("TRACE: :1 %s", msg)
+	input := fmt.Sprintf("std.trace('%s', 'rest')", msg)
+
+	_, err := vm.EvaluateAnonymousSnippet("blah.jsonnet", input)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	actual := removeExcessiveWhitespace(traceOut.String())
+	if actual != expected {
+		t.Errorf("Expected %q, but got %q", expected, actual)
+	}
 }

--- a/jsonnet_test.go
+++ b/jsonnet_test.go
@@ -334,11 +334,12 @@ func TestSetTraceOut(t *testing.T) {
 	vm := MakeVM()
 	vm.SetTraceOut(traceOut)
 
-	const msg = "Some Trace Message"
-	expected := fmt.Sprintf("TRACE: :1 %s", msg)
+	const filename = "blah.jsonnet"
+	const msg = "TestSetTraceOut Trace Message"
+	expected := fmt.Sprintf("TRACE: %s:1 %s", filename, msg)
 	input := fmt.Sprintf("std.trace('%s', 'rest')", msg)
 
-	_, err := vm.EvaluateAnonymousSnippet("blah.jsonnet", input)
+	_, err := vm.EvaluateAnonymousSnippet(filename, input)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/vm.go
+++ b/vm.go
@@ -96,7 +96,7 @@ func (vm *VM) flushValueCache() {
 	vm.importCache.flushValueCache()
 }
 
-// Set the output stream for the builtin function trace(). The default is os.Stderr.
+// SetTraceOut sets the output stream for the builtin function trace(). The default is os.Stderr.
 func (vm *VM) SetTraceOut(traceOut io.Writer) {
 	vm.traceOut = traceOut
 }

--- a/vm.go
+++ b/vm.go
@@ -96,7 +96,7 @@ func (vm *VM) flushValueCache() {
 	vm.importCache.flushValueCache()
 }
 
-// SetTraceOut sets the output stream for the builtin function trace(). The default is os.Stderr.
+// SetTraceOut sets the output stream for the builtin function std.trace().
 func (vm *VM) SetTraceOut(traceOut io.Writer) {
 	vm.traceOut = traceOut
 }

--- a/vm.go
+++ b/vm.go
@@ -19,6 +19,7 @@ package jsonnet
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime/debug"
@@ -44,6 +45,7 @@ type VM struct {
 	ErrorFormatter ErrorFormatter
 	StringOutput   bool
 	importCache    *importCache
+	traceOut       io.Writer
 }
 
 // extKind indicates the kind of external variable that is being initialized for the VM
@@ -78,6 +80,7 @@ func MakeVM() *VM {
 		ErrorFormatter: &termErrorFormatter{pretty: false, maxStackTraceSize: 20},
 		importer:       &FileImporter{},
 		importCache:    makeImportCache(defaultImporter),
+		traceOut:       os.Stderr,
 	}
 }
 
@@ -91,6 +94,11 @@ func (vm *VM) flushCache() {
 // for example due to change in extVars.
 func (vm *VM) flushValueCache() {
 	vm.importCache.flushValueCache()
+}
+
+// Set the output stream for the builtin function trace(). The default is os.Stderr.
+func (vm *VM) SetTraceOut(traceOut io.Writer) {
+	vm.traceOut = traceOut
 }
 
 // ExtVar binds a Jsonnet external var to the given value.
@@ -174,7 +182,7 @@ func (vm *VM) Evaluate(node ast.Node) (val string, err error) {
 			err = fmt.Errorf("(CRASH) %v\n%s", r, debug.Stack())
 		}
 	}()
-	return evaluate(node, vm.ext, vm.tla, vm.nativeFuncs, vm.MaxStack, vm.importCache, vm.StringOutput)
+	return evaluate(node, vm.ext, vm.tla, vm.nativeFuncs, vm.MaxStack, vm.importCache, vm.traceOut, vm.StringOutput)
 }
 
 // EvaluateStream evaluates a Jsonnet program given by an Abstract Syntax Tree
@@ -185,7 +193,7 @@ func (vm *VM) EvaluateStream(node ast.Node) (output []string, err error) {
 			err = fmt.Errorf("(CRASH) %v\n%s", r, debug.Stack())
 		}
 	}()
-	return evaluateStream(node, vm.ext, vm.tla, vm.nativeFuncs, vm.MaxStack, vm.importCache)
+	return evaluateStream(node, vm.ext, vm.tla, vm.nativeFuncs, vm.MaxStack, vm.importCache, vm.traceOut)
 }
 
 // EvaluateMulti evaluates a Jsonnet program given by an Abstract Syntax Tree
@@ -197,7 +205,7 @@ func (vm *VM) EvaluateMulti(node ast.Node) (output map[string]string, err error)
 			err = fmt.Errorf("(CRASH) %v\n%s", r, debug.Stack())
 		}
 	}()
-	return evaluateMulti(node, vm.ext, vm.tla, vm.nativeFuncs, vm.MaxStack, vm.importCache, vm.StringOutput)
+	return evaluateMulti(node, vm.ext, vm.tla, vm.nativeFuncs, vm.MaxStack, vm.importCache, vm.traceOut, vm.StringOutput)
 }
 
 func (vm *VM) evaluateSnippet(diagnosticFileName ast.DiagnosticFileName, filename string, snippet string, kind evalKind) (output interface{}, err error) {
@@ -212,11 +220,11 @@ func (vm *VM) evaluateSnippet(diagnosticFileName ast.DiagnosticFileName, filenam
 	}
 	switch kind {
 	case evalKindRegular:
-		output, err = evaluate(node, vm.ext, vm.tla, vm.nativeFuncs, vm.MaxStack, vm.importCache, vm.StringOutput)
+		output, err = evaluate(node, vm.ext, vm.tla, vm.nativeFuncs, vm.MaxStack, vm.importCache, vm.traceOut, vm.StringOutput)
 	case evalKindMulti:
-		output, err = evaluateMulti(node, vm.ext, vm.tla, vm.nativeFuncs, vm.MaxStack, vm.importCache, vm.StringOutput)
+		output, err = evaluateMulti(node, vm.ext, vm.tla, vm.nativeFuncs, vm.MaxStack, vm.importCache, vm.traceOut, vm.StringOutput)
 	case evalKindStream:
-		output, err = evaluateStream(node, vm.ext, vm.tla, vm.nativeFuncs, vm.MaxStack, vm.importCache)
+		output, err = evaluateStream(node, vm.ext, vm.tla, vm.nativeFuncs, vm.MaxStack, vm.importCache, vm.traceOut)
 	}
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Allow setting a different output stream than `os.Stderr` for `std.trace`.
This is requested by #394.