### PR TITLE
Fix manifest json ex regression

### DIFF
--- a/builtins.go
+++ b/builtins.go
@@ -1211,10 +1211,7 @@ func jsonEncode(v interface{}) (string, error) {
 // For backwards compatibility reasons, we are manually marshalling to json so we can control formatting
 // In the future, it might be apt to use a library [pretty-printing] function
 func builtinManifestJSONEx(i *interpreter, arguments []value) (value, error) {
-	obj, err := i.getObject(arguments[0])
-	if err != nil {
-		return nil, err
-	}
+	val := arguments[0]
 
 	vindent, err := i.getString(arguments[1])
 	if err != nil {
@@ -1315,7 +1312,7 @@ func builtinManifestJSONEx(i *interpreter, arguments []value) (value, error) {
 		}
 	}
 
-	finalString, err := aux(obj, path, "")
+	finalString, err := aux(val, path, "")
 	if err != nil {
 		return nil, err
 	}

--- a/testdata/builtinManifestJsonEx.golden
+++ b/testdata/builtinManifestJsonEx.golden
@@ -1,4 +1,8 @@
 {
-   "a": "{\n  \"bam\": true,\n  \"bar\": \"bar\",\n  \"baz\": 1,\n  \"bazel\": 1.42,\n  \"bim\": false,\n  \"blamo\": {\n    \"cereal\": [\n      \"<>& fizbuzz\"\n    ],\n    \"treats\": [\n      {\n        \"name\": \"chocolate\"\n      }\n    ]\n  },\n  \"boom\": -1,\n  \"foo\": \"bar\"\n}",
-   "b": "[\n  \"bar\",\n  \"bar\",\n  1,\n  1.42,\n  -1,\n  false,\n  true,\n  {\n    \"cereal\": [\n      \"<>& fizbuzz\"\n    ],\n    \"treats\": [\n      {\n        \"name\": \"chocolate\"\n      }\n    ]\n  }\n]"
+   "array": "[\n  \"bar\",\n  \"bar\",\n  1,\n  1.42,\n  -1,\n  false,\n  true,\n  {\n    \"cereal\": [\n      \"<>& fizbuzz\"\n    ],\n    \"treats\": [\n      {\n        \"name\": \"chocolate\"\n      }\n    ]\n  }\n]",
+   "bool": "true",
+   "null": "null",
+   "number": "42",
+   "object": "{\n  \"bam\": true,\n  \"bar\": \"bar\",\n  \"baz\": 1,\n  \"bazel\": 1.42,\n  \"bim\": false,\n  \"blamo\": {\n    \"cereal\": [\n      \"<>& fizbuzz\"\n    ],\n    \"treats\": [\n      {\n        \"name\": \"chocolate\"\n      }\n    ]\n  },\n  \"boom\": -1,\n  \"foo\": \"bar\"\n}",
+   "string": "\"foo\""
 }

--- a/testdata/builtinManifestJsonEx.golden
+++ b/testdata/builtinManifestJsonEx.golden
@@ -1,1 +1,4 @@
-"{\n  \"bam\": true,\n  \"bar\": \"bar\",\n  \"baz\": 1,\n  \"bazel\": 1.42,\n  \"bim\": false,\n  \"blamo\": {\n    \"cereal\": [\n      \"<>& fizbuzz\"\n    ],\n    \"treats\": [\n      {\n        \"name\": \"chocolate\"\n      }\n    ]\n  },\n  \"boom\": -1,\n  \"foo\": \"bar\"\n}"
+{
+   "a": "{\n  \"bam\": true,\n  \"bar\": \"bar\",\n  \"baz\": 1,\n  \"bazel\": 1.42,\n  \"bim\": false,\n  \"blamo\": {\n    \"cereal\": [\n      \"<>& fizbuzz\"\n    ],\n    \"treats\": [\n      {\n        \"name\": \"chocolate\"\n      }\n    ]\n  },\n  \"boom\": -1,\n  \"foo\": \"bar\"\n}",
+   "b": "[\n  \"bar\",\n  \"bar\",\n  1,\n  1.42,\n  -1,\n  false,\n  true,\n  {\n    \"cereal\": [\n      \"<>& fizbuzz\"\n    ],\n    \"treats\": [\n      {\n        \"name\": \"chocolate\"\n      }\n    ]\n  }\n]"
+}

--- a/testdata/builtinManifestJsonEx.jsonnet
+++ b/testdata/builtinManifestJsonEx.jsonnet
@@ -1,4 +1,4 @@
-local a = {
+local object = {
   foo: 'bar',
   bar: self.foo,
   baz: 1,
@@ -19,9 +19,9 @@ local a = {
   },
 };
 
-local b = [
+local array = [
   'bar',
-  a.foo,
+  object.foo,
   1,
   1.42,
   -1,
@@ -41,6 +41,10 @@ local b = [
 ];
 
 {
-  a: std.manifestJsonEx(a, '  '),
-  b: std.manifestJsonEx(b, '  '),
+  array: std.manifestJsonEx(array, '  '),
+  bool: std.manifestJsonEx(true, '   '),
+  'null': std.manifestJsonEx(null, '   '),
+  object: std.manifestJsonEx(object, '  '),
+  number: std.manifestJsonEx(42, '   '),
+  string: std.manifestJsonEx('foo', '   '),
 }

--- a/testdata/builtinManifestJsonEx.jsonnet
+++ b/testdata/builtinManifestJsonEx.jsonnet
@@ -1,22 +1,46 @@
 local a = {
-    foo: "bar",
-    bar: self.foo,
-    baz: 1,
-    bazel: 1.42,
-    boom: -1,
-    bim: false,
-    bam: true,
-    blamo: {
-        cereal: [
-            "<>& fizbuzz",
-        ],
+  foo: 'bar',
+  bar: self.foo,
+  baz: 1,
+  bazel: 1.42,
+  boom: -1,
+  bim: false,
+  bam: true,
+  blamo: {
+    cereal: [
+      '<>& fizbuzz',
+    ],
 
-        treats: [
-            {
-                name: "chocolate",
-            }
-        ],
-    }
+    treats: [
+      {
+        name: 'chocolate',
+      },
+    ],
+  },
 };
 
-std.manifestJsonEx(a, "  ")
+local b = [
+  'bar',
+  a.foo,
+  1,
+  1.42,
+  -1,
+  false,
+  true,
+  {
+    cereal: [
+      '<>& fizbuzz',
+    ],
+
+    treats: [
+      {
+        name: 'chocolate',
+      },
+    ],
+  },
+];
+
+{
+  a: std.manifestJsonEx(a, '  '),
+  b: std.manifestJsonEx(b, '  '),
+}


### PR DESCRIPTION
This PR fixes a regression in std.manifestJsonEx that caused the
standard library function to error when the given value was an array.
It also adds a test case to prevent regressions in
std.manifestJsonEx accepting arrays as values.

fixes: #515 

Implements fix suggested by @sbarzowski in https://github.com/google/go-jsonnet/issues/515#issuecomment-779123853