### PR TITLE
updated pre-commit config and readme

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,15 @@
-# How to use pre-commit hook: https://pre-commit.com
 - id: jsonnet-format
-  name: Format fix for jsonnet/libsonnet files
-  entry: jsonnetfmt -i
+  name: jsonnetfmt
+  description: Automatically format jsonnet files.
+  entry: jsonnetfmt
+  args: [-i]
   language: golang
-  files: '\.(jsonnet|libsonnet)$'
-  additional_dependencies: [ "github.com/google/go-jsonnet/cmd/jsonnetfmt" ]
+  files: \.(jsonnet|libsonnet)$
+  minimum_pre_commit_version: 2.10.1
+- id: jsonnet-lint
+  name: jsonnet-lint
+  description: Lint jsonnet files.
+  entry: jsonnet-lint
+  language: golang
+  files: \.(jsonnet|libsonnet)$
+  minimum_pre_commit_version: 2.10.1

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ It's also available on Homebrew:
 brew install go-jsonnet
 ```
 
+`jsonnetfmt` and `jsonnet-lint` are also available as [pre-commit](https://github.com/pre-commit/pre-commit) hooks. Example `.pre-commit-config.yaml`:
+```yaml
+- repo: https://github.com/google/go-jsonnet
+  rev: # ref you want to point at, e.g. v0.17.0
+  hooks:
+    - id: jsonnet-format
+    - id: jsonnet-lint
+```
+
 ## Build instructions (go 1.11+)
 
 ```bash


### PR DESCRIPTION
updates / extends #512:

- documented usage in `README.md`
- added `jsonnet-lint` to available hooks
- set `minimum_pre_commit_version` to `2.10.1`, see [this](https://github.com/pre-commit/pre-commit/pull/1789) PR which was [added](https://github.com/pre-commit/pre-commit/releases/tag/v2.10.1) in `v2.10.1`
- removed `additional_dependencies` as pre-commit automatically installs the cloned repository. (the way the hook was configured before caused a duplicate clone and installation).