### PR TITLE
Support different output streams than os.Stderr for std.trace (C API)

### DIFF
--- a/c-bindings-tests/compat_test.py
+++ b/c-bindings-tests/compat_test.py
@@ -131,7 +131,8 @@ lib.jsonnet_import_callback.restype = None
 
 IO_WRITER_CALLBACK = ctypes.CFUNCTYPE(
     ctypes.c_int,
-    ctypes.c_char_p,
+    ctypes.c_void_p,
+    ctypes.c_size_t,
     ctypes.POINTER(ctypes.c_int)
 )
 
@@ -355,11 +356,11 @@ def import_callback(ctx, dir, rel, found_here, success):
 io_writer_buf = None
 
 @IO_WRITER_CALLBACK
-def io_writer_callback(p, success):
+def io_writer_callback(buf, nbytes, success):
     global io_writer_buf
-    io_writer_buf = p
+    io_writer_buf = ctypes.string_at(buf, nbytes)
     success[0] = ctypes.c_int(1)
-    return len(p)
+    return nbytes
 
 #  Returns content if worked, None if file not found, or throws an exception
 def jsonnet_try_path(dir, rel):

--- a/c-bindings-tests/compat_test.py
+++ b/c-bindings-tests/compat_test.py
@@ -518,7 +518,7 @@ class TestJsonnetEvaluateBindings(unittest.TestCase):
         msg = b"test_jsonnet_set_trace_out_callback trace message"
         expected = b"TRACE: " + fname + b":1 " + msg + b"\n"
         snippet = b"std.trace('" + msg + b"', 'rest')"
-        res = lib.jsonnet_evaluate_snippet(self.vm, fname, snippet, self.err_ref)
+        lib.jsonnet_evaluate_snippet(self.vm, fname, snippet, self.err_ref)
         self.assertEqual(io_writer_buf,  expected)
 
     def tearDown(self):

--- a/c-bindings-tests/compat_test.py
+++ b/c-bindings-tests/compat_test.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-import unittest
 import ctypes
-import re
+import io
 import os
+import re
+import unittest
 
 
 lib = ctypes.CDLL('../c-bindings/libgojsonnet.so')
@@ -127,6 +128,18 @@ lib.jsonnet_import_callback.argtypes = [
     ctypes.c_void_p,
 ]
 lib.jsonnet_import_callback.restype = None
+
+IO_WRITER_CALLBACK = ctypes.CFUNCTYPE(
+    ctypes.c_int,
+    ctypes.c_char_p,
+    ctypes.POINTER(ctypes.c_int)
+)
+
+lib.jsonnet_set_trace_out_callback.argtypes = [
+    ctypes.c_void_p,
+    IO_WRITER_CALLBACK,
+]
+lib.jsonnet_set_trace_out_callback.restype = None
 
 # json declaration
 
@@ -339,6 +352,15 @@ def import_callback(ctx, dir, rel, found_here, success):
 
     return ctypes.addressof(dst.contents)
 
+io_writer_buf = None
+
+@IO_WRITER_CALLBACK
+def io_writer_callback(p, success):
+    global io_writer_buf
+    io_writer_buf = p
+    success[0] = ctypes.c_int(1)
+    return len(p)
+
 #  Returns content if worked, None if file not found, or throws an exception
 def jsonnet_try_path(dir, rel):
     if not rel:
@@ -489,6 +511,15 @@ class TestJsonnetEvaluateBindings(unittest.TestCase):
         res = lib.jsonnet_evaluate_snippet(self.vm, b"jsonnet_import_callback", b"""import 'foo.jsonnet'""", self.err_ref)
         self.assertEqual(b'42\n', to_bytes(res))
         free_buffer(self.vm, res)
+
+    def test_jsonnet_set_trace_out_callback(self):
+        lib.jsonnet_set_trace_out_callback(self.vm, io_writer_callback)
+        fname = b"vm1"
+        msg = b"test_jsonnet_set_trace_out_callback trace message"
+        expected = b"TRACE: " + fname + b":1 " + msg + b"\n"
+        snippet = b"std.trace('" + msg + b"', 'rest')"
+        res = lib.jsonnet_evaluate_snippet(self.vm, fname, snippet, self.err_ref)
+        self.assertEqual(io_writer_buf,  expected)
 
     def tearDown(self):
         lib.jsonnet_destroy(self.vm)

--- a/c-bindings/c-bindings.go
+++ b/c-bindings/c-bindings.go
@@ -648,6 +648,9 @@ func (o *traceOut) Write(p []byte) (int, error) {
 	str := C.CString(string(p))
 	var n C.int = C.jsonnet_internal_execute_writer(o.cb, str, &success)
 	C.jsonnet_internal_free_string(str)
+	if success != 1 {
+		return int(n), errors.New("std.trace() failed to write to output stream")
+	}
 	return int(n), nil
 }
 

--- a/c-bindings/c-bindings.go
+++ b/c-bindings/c-bindings.go
@@ -649,7 +649,8 @@ func (o *traceOut) Write(p []byte) (int, error) {
 	}
 
 	success := C.int(0)
-	var n C.int = C.jsonnet_internal_execute_writer(o.cb, (*C.char)(unsafe.Pointer(&p[0])), &success)
+	var n C.int = C.jsonnet_internal_execute_writer(o.cb, unsafe.Pointer(&p[0]),
+				                                    C.size_t(len(p)), &success)
 	if success != 1 {
 		return int(n), errors.New("std.trace() failed to write to output stream")
 	}

--- a/c-bindings/c-bindings.go
+++ b/c-bindings/c-bindings.go
@@ -639,5 +639,23 @@ func formatSnippet(vmRef *C.struct_JsonnetVm, filename string, code string, e *C
 	return result
 }
 
+type traceOut struct {
+	cb *C.JsonnetIoWriterCallback
+}
+
+func (o *traceOut) Write(p []byte) (int, error) {
+	success := C.int(0)
+	str := C.CString(string(p))
+	var n C.int = C.jsonnet_internal_execute_writer(o.cb, str, &success)
+	C.jsonnet_internal_free_string(str)
+	return int(n), nil
+}
+
+//export jsonnet_set_trace_out_callback
+func jsonnet_set_trace_out_callback(vmRef *C.struct_JsonnetVm, cb *C.JsonnetIoWriterCallback) {
+	vm := getVM(vmRef)
+	vm.SetTraceOut(&traceOut{cb})
+}
+
 func main() {
 }

--- a/c-bindings/c-bindings.go
+++ b/c-bindings/c-bindings.go
@@ -644,10 +644,12 @@ type traceOut struct {
 }
 
 func (o *traceOut) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
 	success := C.int(0)
-	str := C.CString(string(p))
-	var n C.int = C.jsonnet_internal_execute_writer(o.cb, str, &success)
-	C.jsonnet_internal_free_string(str)
+	var n C.int = C.jsonnet_internal_execute_writer(o.cb, (*C.char)(unsafe.Pointer(&p[0])), &success)
 	if success != 1 {
 		return int(n), errors.New("std.trace() failed to write to output stream")
 	}

--- a/c-bindings/internal.h
+++ b/c-bindings/internal.h
@@ -38,4 +38,10 @@ char* jsonnet_internal_execute_import(JsonnetImportCallback *cb,
                                       char **found_here,
                                       int *success);
 
+typedef int JsonnetIoWriterCallback(char *str, int *success);
+
+int jsonnet_internal_execute_writer(JsonnetIoWriterCallback *cb,
+                                    char *str,
+                                    int *success);
+
 void jsonnet_internal_free_string(char *str);

--- a/c-bindings/internal.h
+++ b/c-bindings/internal.h
@@ -38,10 +38,11 @@ char* jsonnet_internal_execute_import(JsonnetImportCallback *cb,
                                       char **found_here,
                                       int *success);
 
-typedef int JsonnetIoWriterCallback(char *str, int *success);
+typedef int JsonnetIoWriterCallback(const void *buf, size_t nbytes, int *success);
 
 int jsonnet_internal_execute_writer(JsonnetIoWriterCallback *cb,
-                                    char *str,
+                                    const void *buf,
+                                    size_t nbytes,
                                     int *success);
 
 void jsonnet_internal_free_string(char *str);

--- a/c-bindings/libjsonnet.cpp
+++ b/c-bindings/libjsonnet.cpp
@@ -44,6 +44,13 @@ char* jsonnet_internal_execute_import(JsonnetImportCallback *cb,
     return (cb)(ctx, base, rel, found_here, success);
 }
 
+int jsonnet_internal_execute_writer(JsonnetIoWriterCallback *cb,
+                                    char *str,
+                                    int *success)
+{
+    return (cb)(str, success);
+}
+
 void jsonnet_internal_free_string(char *str) {
     if (str != nullptr) {
         ::free(str);

--- a/c-bindings/libjsonnet.cpp
+++ b/c-bindings/libjsonnet.cpp
@@ -45,10 +45,11 @@ char* jsonnet_internal_execute_import(JsonnetImportCallback *cb,
 }
 
 int jsonnet_internal_execute_writer(JsonnetIoWriterCallback *cb,
-                                    char *str,
+                                    const void *buf,
+                                    size_t nbytes,
                                     int *success)
 {
-    return (cb)(str, success);
+    return (cb)(buf, nbytes, success);
 }
 
 void jsonnet_internal_free_string(char *str) {


### PR DESCRIPTION
Requested by #394 
