### PR TITLE
IdentifierSet performance improvements

### DIFF
--- a/ast/identifier_set.go
+++ b/ast/identifier_set.go
@@ -22,9 +22,11 @@ func NewIdentifierSet(a ...Identifier) IdentifierSet {
 
 // ToSlice returns the elements of the current set as a slice
 func (set IdentifierSet) ToSlice() []Identifier {
-	var s []Identifier
+	s := make([]Identifier, len(set), len(set))
+	j := 0
 	for v := range set {
-		s = append(s, v)
+		s[j] = v
+		j++
 	}
 	return s
 }

--- a/ast/util.go
+++ b/ast/util.go
@@ -29,9 +29,11 @@ func (i IdentifierSet) AddIdentifiers(idents Identifiers) {
 
 // ToOrderedSlice returns the elements of the current set as an ordered slice.
 func (i IdentifierSet) ToOrderedSlice() []Identifier {
-	var s []Identifier
+	s := make([]Identifier, len(i), len(i))
+	j := 0
 	for v := range i {
-		s = append(s, v)
+		s[j] = v
+		j++
 	}
 	sort.Sort(identifierSorter(s))
 	return s

--- a/ast/util_test.go
+++ b/ast/util_test.go
@@ -1,0 +1,64 @@
+package ast
+
+import (
+	"fmt"
+	"testing"
+)
+
+func testIdentifiers(n int) Identifiers {
+	var is []Identifier
+	for i := 0; i < n; i++ {
+		is = append(is, Identifier(fmt.Sprintf("id-%06d", i)))
+	}
+	return Identifiers(is)
+}
+
+var results []Identifier
+
+func BenchmarkToOrderedSlice(b *testing.B) {
+	tests := []Identifiers{
+		testIdentifiers(1),
+		testIdentifiers(10),
+		testIdentifiers(100),
+		testIdentifiers(1000),
+		testIdentifiers(10000),
+		testIdentifiers(100000),
+	}
+
+	for _, t := range tests {
+		is := IdentifierSet{}
+		is.AddIdentifiers(t)
+
+		b.Run(fmt.Sprintf("%d unique identifiers", len(t)), func(b *testing.B) {
+			var r []Identifier
+			for i := 0; i < b.N; i++ {
+				r = is.ToOrderedSlice()
+			}
+			results = r
+		})
+	}
+}
+
+func BenchmarkToSlice(b *testing.B) {
+	tests := []Identifiers{
+		testIdentifiers(1),
+		testIdentifiers(10),
+		testIdentifiers(100),
+		testIdentifiers(1000),
+		testIdentifiers(10000),
+		testIdentifiers(100000),
+	}
+
+	for _, t := range tests {
+		is := IdentifierSet{}
+		is.AddIdentifiers(t)
+
+		b.Run(fmt.Sprintf("%d unique identifiers", len(t)), func(b *testing.B) {
+			var r []Identifier
+			for i := 0; i < b.N; i++ {
+				r = is.ToSlice()
+			}
+			results = r
+		})
+	}
+}


### PR DESCRIPTION
Hello. While profiling another tool ([Grafana's Tanka](https://github.com/grafana/tanka)) I've found that 13% of memory profiling was spent at `ast.IdentifierSet.ToOrderedSlice`. After checking the code I've found a small change that drastically improves not only memory consumption in a stable way (only 2 allocations per call to `ToOrderSlice`, regardless the size of the output slice) but drastically improves the performance of this and `ToSlice` methods.

I've added some benchmarks to test this and found the following: with the code at [current master](https://github.com/google/go-jsonnet/blob/63a452246db4e1eda7d55daea445f83c7bbf1b5d/ast/util.go#L31-L38) I get these numbers:

```
goos: darwin
goarch: amd64
pkg: github.com/google/go-jsonnet/ast
cpu: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
BenchmarkToOrderedSlice/1_unique_identifiers-8           6445634               175.3 ns/op            40 B/op          2 allocs/op
BenchmarkToOrderedSlice/10_unique_identifiers-8           871934              1356 ns/op             520 B/op          6 allocs/op
BenchmarkToOrderedSlice/100_unique_identifiers-8           60790             19291 ns/op            4104 B/op          9 allocs/op
BenchmarkToOrderedSlice/1000_unique_identifiers-8           3883            260751 ns/op           32785 B/op         12 allocs/op
BenchmarkToOrderedSlice/10000_unique_identifiers-8           343           3523511 ns/op          826040 B/op         21 allocs/op
BenchmarkToOrderedSlice/100000_unique_identifiers-8           22          49308257 ns/op         9248112 B/op         31 allocs/op
BenchmarkToSlice/1_unique_identifiers-8                 11676297               101.8 ns/op            16 B/op          1 allocs/op
BenchmarkToSlice/10_unique_identifiers-8                 1467850               837.8 ns/op           496 B/op          5 allocs/op
BenchmarkToSlice/100_unique_identifiers-8                 245740              4848 ns/op            4080 B/op          8 allocs/op
BenchmarkToSlice/1000_unique_identifiers-8                 31818             38298 ns/op           32752 B/op         11 allocs/op
BenchmarkToSlice/10000_unique_identifiers-8                 1701            620139 ns/op          825977 B/op         20 allocs/op
BenchmarkToSlice/100000_unique_identifiers-8                 138          10201763 ns/op         9247347 B/op         30 allocs/op
PASS
ok      github.com/google/go-jsonnet/ast        18.370s
```

As you can see, the number of allocations and bytes per operation depends on the size of the underlying map.

With the changes proposed in this PR, I'm getting these numbers instead:

```
goos: darwin
goarch: amd64
pkg: github.com/google/go-jsonnet/ast
cpu: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
BenchmarkToOrderedSlice/1_unique_identifiers-8           7902704               149.7 ns/op            40 B/op          2 allocs/op
BenchmarkToOrderedSlice/10_unique_identifiers-8          1627670               738.4 ns/op           184 B/op          2 allocs/op
BenchmarkToOrderedSlice/100_unique_identifiers-8           75212             15804 ns/op            1816 B/op          2 allocs/op
BenchmarkToOrderedSlice/1000_unique_identifiers-8           5390            220327 ns/op           16413 B/op          2 allocs/op
BenchmarkToOrderedSlice/10000_unique_identifiers-8           426           2853913 ns/op          163883 B/op          2 allocs/op
BenchmarkToOrderedSlice/100000_unique_identifiers-8           32          37886116 ns/op         1606168 B/op          2 allocs/op
BenchmarkToSlice/1_unique_identifiers-8                 14197999                83.31 ns/op           16 B/op          1 allocs/op
BenchmarkToSlice/10_unique_identifiers-8                 4179153               291.0 ns/op           160 B/op          1 allocs/op
BenchmarkToSlice/100_unique_identifiers-8                 499405              2372 ns/op            1792 B/op          1 allocs/op
BenchmarkToSlice/1000_unique_identifiers-8                 47860             25045 ns/op           16384 B/op          1 allocs/op
BenchmarkToSlice/10000_unique_identifiers-8                 5781            222580 ns/op          163842 B/op          1 allocs/op
BenchmarkToSlice/100000_unique_identifiers-8                 532           2284904 ns/op         1605634 B/op          1 allocs/op
PASS
ok      github.com/google/go-jsonnet/ast        17.753s
```

Performant was improved in all places by orders of magnitude, as reported by [`benchstat`](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat):

```
name                                        old time/op    new time/op    delta
ToOrderedSlice/1_unique_identifiers-8          200ns _ 9%     149ns _ 2%  -25.30%  (p=0.000 n=19+20)
ToOrderedSlice/10_unique_identifiers-8        1.52_s _16%    0.73_s _ 4%  -51.86%  (p=0.000 n=19+17)
ToOrderedSlice/100_unique_identifiers-8       22.2_s _13%    15.8_s _ 2%  -28.64%  (p=0.000 n=19+20)
ToOrderedSlice/1000_unique_identifiers-8       280_s _ 7%     222_s _ 1%  -20.72%  (p=0.000 n=18+19)
ToOrderedSlice/10000_unique_identifiers-8     3.90ms _10%    2.86ms _ 1%  -26.85%  (p=0.000 n=18+19)
ToOrderedSlice/100000_unique_identifiers-8    61.7ms _20%    38.4ms _ 2%  -37.80%  (p=0.000 n=18+20)
ToSlice/1_unique_identifiers-8                 115ns _ 7%      83ns _ 1%  -27.91%  (p=0.000 n=18+17)
ToSlice/10_unique_identifiers-8                940ns _15%     293ns _ 1%  -68.84%  (p=0.000 n=18+18)
ToSlice/100_unique_identifiers-8              5.48_s _17%    2.40_s _ 6%  -56.23%  (p=0.000 n=19+19)
ToSlice/1000_unique_identifiers-8             44.2_s _16%    25.3_s _ 7%  -42.92%  (p=0.000 n=19+20)
ToSlice/10000_unique_identifiers-8             737_s _17%     222_s _ 2%  -69.83%  (p=0.000 n=19+19)
ToSlice/100000_unique_identifiers-8           10.3ms _13%     2.2ms _ 1%  -78.52%  (p=0.000 n=18+18)

name                                        old alloc/op   new alloc/op   delta
ToOrderedSlice/1_unique_identifiers-8          40.0B _ 0%     40.0B _ 0%     ~     (all equal)
ToOrderedSlice/10_unique_identifiers-8          520B _ 0%      184B _ 0%  -64.62%  (p=0.000 n=20+20)
ToOrderedSlice/100_unique_identifiers-8       4.10kB _ 0%    1.82kB _ 0%  -55.75%  (p=0.000 n=20+20)
ToOrderedSlice/1000_unique_identifiers-8      32.8kB _ 0%    16.4kB _ 0%  -49.93%  (p=0.000 n=18+18)
ToOrderedSlice/10000_unique_identifiers-8      826kB _ 0%     164kB _ 0%  -80.16%  (p=0.000 n=16+17)
ToOrderedSlice/100000_unique_identifiers-8    9.25MB _ 0%    1.61MB _ 0%  -82.63%  (p=0.000 n=18+17)
ToSlice/1_unique_identifiers-8                 16.0B _ 0%     16.0B _ 0%     ~     (all equal)
ToSlice/10_unique_identifiers-8                 496B _ 0%      160B _ 0%  -67.74%  (p=0.000 n=20+20)
ToSlice/100_unique_identifiers-8              4.08kB _ 0%    1.79kB _ 0%  -56.08%  (p=0.000 n=20+20)
ToSlice/1000_unique_identifiers-8             32.8kB _ 0%    16.4kB _ 0%  -49.98%  (p=0.000 n=20+20)
ToSlice/10000_unique_identifiers-8             826kB _ 0%     164kB _ 0%  -80.16%  (p=0.000 n=20+20)
ToSlice/100000_unique_identifiers-8           9.25MB _ 0%    1.61MB _ 0%  -82.64%  (p=0.000 n=20+20)

name                                        old allocs/op  new allocs/op  delta
ToOrderedSlice/1_unique_identifiers-8           2.00 _ 0%      2.00 _ 0%     ~     (all equal)
ToOrderedSlice/10_unique_identifiers-8          6.00 _ 0%      2.00 _ 0%  -66.67%  (p=0.000 n=20+20)
ToOrderedSlice/100_unique_identifiers-8         9.00 _ 0%      2.00 _ 0%  -77.78%  (p=0.000 n=20+20)
ToOrderedSlice/1000_unique_identifiers-8        12.0 _ 0%       2.0 _ 0%  -83.33%  (p=0.000 n=20+20)
ToOrderedSlice/10000_unique_identifiers-8       21.0 _ 0%       2.0 _ 0%  -90.48%  (p=0.000 n=20+20)
ToOrderedSlice/100000_unique_identifiers-8      31.0 _ 0%       2.0 _ 0%  -93.55%  (p=0.000 n=20+20)
ToSlice/1_unique_identifiers-8                  1.00 _ 0%      1.00 _ 0%     ~     (all equal)
ToSlice/10_unique_identifiers-8                 5.00 _ 0%      1.00 _ 0%  -80.00%  (p=0.000 n=20+20)
ToSlice/100_unique_identifiers-8                8.00 _ 0%      1.00 _ 0%  -87.50%  (p=0.000 n=20+20)
ToSlice/1000_unique_identifiers-8               11.0 _ 0%       1.0 _ 0%  -90.91%  (p=0.000 n=20+20)
ToSlice/10000_unique_identifiers-8              20.0 _ 0%       1.0 _ 0%  -95.00%  (p=0.000 n=20+20)
ToSlice/100000_unique_identifiers-8             30.0 _ 0%       1.0 _ 0%  -96.67%  (p=0.000 n=20+20)
```

I recompiled my local Tanka using these improvements and now when profiling output this method isn't listed anymore, not even in the `top 10` output.