### PR TITLE
linter: correct the return type for member

### DIFF
--- a/linter/internal/types/stdlib.go
+++ b/linter/internal/types/stdlib.go
@@ -118,7 +118,7 @@ func prepareStdlib(g *typeGraph) {
 
 		"makeArray":     g.newSimpleFuncType(anyArrayType, "sz", "func"),
 		"count":         g.newSimpleFuncType(numberType, "arr", "x"),
-		"member":        g.newSimpleFuncType(numberType, "arr", "x"),
+		"member":        g.newSimpleFuncType(boolType, "arr", "x"),
 		"find":          g.newSimpleFuncType(arrayOfNumber, "value", "arr"),
 		"map":           g.newSimpleFuncType(anyArrayType, "func", "arr"),
 		"mapWithIndex":  g.newSimpleFuncType(anyArrayType, "func", "arr"),


### PR DESCRIPTION
This commit corrects return type of the `member` function from the
standard library.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>