### PR TITLE
Fix jsonnet-lint erorr when linting importing files and imported files at the same time: #544

### DIFF
--- a/imports.go
+++ b/imports.go
@@ -117,6 +117,15 @@ func (cache *importCache) importData(importedFrom, importedPath string) (content
 	return
 }
 
+func (cache *importCache) snippetToAST(diagnosticFilename ast.DiagnosticFileName, importedFilename, snippet string) (ast.Node, error) {
+	if cachedNode, isCached := cache.astCache[importedFilename]; isCached {
+		return cachedNode, nil
+	}
+	node, err := program.SnippetToAST(diagnosticFilename, importedFilename, snippet)
+	cache.astCache[importedFilename] = node
+	return node, err
+}
+
 func (cache *importCache) importAST(importedFrom, importedPath string) (ast.Node, string, error) {
 	contents, foundAt, err := cache.importData(importedFrom, importedPath)
 	if err != nil {

--- a/jsonnet_test.go
+++ b/jsonnet_test.go
@@ -290,11 +290,11 @@ func assertVarOutput(t *testing.T, jsonStr string) {
 }
 
 func TestExtTypes(t *testing.T) {
-	node, err := SnippetToAST("var.jsonnet", `{ node: 'node' }`)
+	vm := MakeVM()
+	node, err := vm.SnippetToAST("var.jsonnet", `{ node: 'node' }`)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	vm := MakeVM()
 	vm.ExtVar("var", "var")
 	vm.ExtCode("code", `{ code: 'code'}`)
 	vm.ExtNode("node", node)
@@ -310,11 +310,11 @@ func TestExtTypes(t *testing.T) {
 }
 
 func TestTLATypes(t *testing.T) {
-	node, err := SnippetToAST("var.jsonnet", `{ node: 'node' }`)
+	vm := MakeVM()
+	node, err := vm.SnippetToAST("var.jsonnet", `{ node: 'node' }`)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	vm := MakeVM()
 	vm.TLAVar("var", "var")
 	vm.TLACode("code", `{ code: 'code'}`)
 	vm.TLANode("node", node)

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -140,7 +140,7 @@ func LintSnippet(vm *jsonnet.VM, output io.Writer, snippets []Snippet) bool {
 
 	var nodes []nodeWithLocation
 	for _, snippet := range snippets {
-		node, err := jsonnet.SnippetToAST(snippet.FileName, snippet.Code)
+		node, err := vm.SnippetToAST(snippet.FileName, snippet.Code)
 
 		if err != nil {
 			errWriter.writeError(vm, err.(errors.StaticError)) // ugly but true

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -104,6 +104,23 @@ func runTests(t *testing.T, tests []*linterTest) {
 	if outData != "" && !errorsFound {
 		t.Error(fmt.Errorf("return value indicates no problems, but output is not empty:\n%v", outData))
 	}
+
+	// passing as args for both importing file and imported file.
+	var import_snippets []Snippet
+
+	for _, filepath := range []string{"testdata/import.jsonnet", "testdata/call_integer.jsonnet"} {
+		input := read(filepath)
+		import_snippets = append(import_snippets, Snippet{FileName: filepath, Code: string(input)})
+	}
+
+	errorsFound = LintSnippet(vm, &outBuilder, snippets)
+	outData = outBuilder.String()
+	if outData == "" && errorsFound {
+		t.Error(fmt.Errorf("return value indicates problems present, but no output was produced"))
+	}
+	if outData != "" && !errorsFound {
+		t.Error(fmt.Errorf("return value indicates no problems, but output is not empty:\n%v", outData))
+	}
 }
 
 func TestLinter(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -146,7 +146,7 @@ func runInternalJsonnet(i jsonnetInput) jsonnetResult {
 	}
 	testChildren(rawAST)
 
-	desugaredAST, err := SnippetToAST(i.name, string(i.input))
+	desugaredAST, err := vm.SnippetToAST(i.name, string(i.input))
 	if err != nil {
 		return jsonnetResult{
 			output:  errFormatter.Format(err) + "\n",

--- a/vm.go
+++ b/vm.go
@@ -514,8 +514,8 @@ func (vm *VM) ImportAST(importedFrom, importedPath string) (contents ast.Node, f
 }
 
 // SnippetToAST parses a snippet and returns the resulting AST.
-func SnippetToAST(filename string, snippet string) (ast.Node, error) {
-	return program.SnippetToAST(ast.DiagnosticFileName(filename), filename, snippet)
+func (vm *VM) SnippetToAST(filename string, snippet string) (ast.Node, error) {
+	return vm.importCache.snippetToAST(ast.DiagnosticFileName(filename), filename, snippet)
 }
 
 // Version returns the Jsonnet version number.


### PR DESCRIPTION
This PR aims to fix #544.

I also encounter #544 (the same case with https://github.com/google/go-jsonnet/issues/544#issuecomment-877622528)

Please let me know if my understanding is wrong.
The problem seems to be caused by XxxtoAST (`ImportAST` and `SnippetToAST`) functions return different Node instances, even with the same arguments.
Specifically, about using the `ast.Node` cache. `ImportAST` function (call `SnippetToAST` function internally) uses `ast.Node` cache, while a direct call of `SnippetToAST` function does not use the cache.
So, the return values are different (e.g. `LocationRange.File`).
This will results missing key at `getExprPlaceholder`.

To fix this problem, I made changes to `SnippetToAST` to use the same cache with `ImportAST`.
