### PR TITLE
Add maintainer info to a deb package of jsonnetfmt

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -79,6 +79,7 @@ nfpms:
     formats:
       - deb
     bindir: /usr/bin
+    maintainer: David Cunningham <dcunnin@google.com>
     file_name_template: "jsonnetfmt-go_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     overrides:
       deb:


### PR DESCRIPTION
Fix #542.

This PR adding maintainer info to a deb package of `jsonnetfmt`.
