### PR TITLE
Fix gorelaser configs to properly build darwin packages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
       - arm64
     ignore:
       - goos: darwin
-      - goarch: 386
+        goarch: 386
 
     id: jsonnet
     main: ./cmd/jsonnet
@@ -36,7 +36,7 @@ builds:
       - arm64
     ignore:
       - goos: darwin
-      - goarch: 386
+        goarch: 386
 
     id: jsonnetfmt
     main: ./cmd/jsonnetfmt


### PR DESCRIPTION
This PR aims to add packages for `macOS` at releases.
For now, binary packages for macOS are missing at the release page even though `goreleaser` settings include macOS at `goos`.
This is because ignore config of `goreleaser` are incorrect.
In the current config, all of the macOS(`darwin`) will be ignored.
