### PR TITLE
Document installation for go >= 1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ This code is known to work on Go 1.12 and above. We recommend always using the n
 
 ## Installation instructions
 
-```
+```shell
+# go >= 1.17
+# Using `go get` to install binaries is deprecated.
+# The version suffix is mandatory.
+go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+
+# go < 1.17
 go get github.com/google/go-jsonnet/cmd/jsonnet
 ```
 


### PR DESCRIPTION
Since go `1.17` the installation of binaries with `go get` is deprecated. The README.md was updated to reflect this.

I also highlighted the fact that the version suffix is mandatory. This information can be found by running `go help install`, but I believe explicitly specifying it may reduce the entry barrier.  