### PR TITLE
Update to the latest rules_go and use the new keyword argument when registering toolchains

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -11,7 +11,7 @@ load(
 
 def jsonnet_go_dependencies():
     go_rules_dependencies()
-    go_register_toolchains(version = "host")
+    go_register_toolchains(go_version = "host")
     gazelle_dependencies()
     go_repository(
         name = "com_github_davecgh_go_spew",

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -6,10 +6,10 @@ load(
 def jsonnet_go_repositories():
     http_archive(
         name = "io_bazel_rules_go",
-        sha256 = "7904dbecbaffd068651916dce77ff3437679f9d20e1a7956bff43826e7645fcc",
+        sha256 = "2b1641428dff9018f9e85c0384f03ec6c10660d935b750e3fa1492a281a53b0f",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.25.1/rules_go-v0.25.1.tar.gz",
-            "https://github.com/bazelbuild/rules_go/releases/download/v0.25.1/rules_go-v0.25.1.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip",
+            "https://github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip",
         ],
     )
 


### PR DESCRIPTION
The newer version of rules_go gets added by other rules and causes a failure when registering toolchains with the wrong keyword argument.