### PR TITLE
feat: Add missing linter metadata for std.manifestTomlEx function

### DIFF
--- a/linter/internal/types/stdlib.go
+++ b/linter/internal/types/stdlib.go
@@ -109,6 +109,7 @@ func prepareStdlib(g *typeGraph) {
 		"manifestIni":        g.newSimpleFuncType(stringType, "ini"),
 		"manifestPython":     g.newSimpleFuncType(stringType, "v"),
 		"manifestPythonVars": g.newSimpleFuncType(stringType, "conf"),
+		"manifestTomlEx":     g.newSimpleFuncType(stringType, "value", "indent"),
 		"manifestJsonEx":     g.newSimpleFuncType(stringType, "value", "indent"),
 		"manifestYamlDoc":    g.newSimpleFuncType(stringType, "value"),
 		"manifestYamlStream": g.newSimpleFuncType(stringType, "value"),

--- a/testdata/stdlib_smoke_test.golden
+++ b/testdata/stdlib_smoke_test.golden
@@ -108,6 +108,7 @@
    "manifestJsonEx": "{\n \"a\": {\n  \"b\": \"c\"\n }\n}",
    "manifestPython": "{\"a\": {\"b\": \"c\"}}",
    "manifestPythonVars": "a = {\"b\": \"c\"}\n",
+   "manifestTomlEx": "\n\n[a]\n b = \"c\"",
    "manifestXmlJsonml": "<blah a=\"42\"></blah>",
    "manifestYamlDoc": "\"a\":\n  \"b\": \"c\"",
    "manifestYamlStream": "---\n42\n---\n\"a\":\n  \"b\": \"c\"\n...\n",

--- a/testdata/stdlib_smoke_test.jsonnet
+++ b/testdata/stdlib_smoke_test.jsonnet
@@ -93,6 +93,7 @@
     manifestIni: std.manifestIni(ini={main: {a: 1, b:2}, sections: {s1: {x: 1, y: 2}}}),
     manifestPython: std.manifestPython(v={a: {b: "c"}}),
     manifestPythonVars: std.manifestPythonVars(conf={a: {b: "c"}}),
+    manifestTomlEx: std.manifestTomlEx(value={a: {b: "c"}}, indent=" "),
     manifestJsonEx: std.manifestJsonEx(value={a: {b: "c"}}, indent=" "),
     manifestYamlDoc: std.manifestYamlDoc(value={a: {b: "c"}}),
     manifestYamlStream: std.manifestYamlStream(value=[42, {a: {b: "c"}}]),


### PR DESCRIPTION
Fixes #587