### PR TITLE
Bump Go build version to 1.17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.17
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
I don't mean to overstep, so please, feel free to drop this one. But maybe this PR has an encouraging effect.

My motivation for this PR is to make the darwin_arm64 artifact available as part of the release. At this point, [Goreleaser](https://github.com/goreleaser/goreleaser/issues/1952) automatically supports it, if the go version, used to build the artifact, is >= 1.16

The *Installation instructions* already refers to Go v1.17 and above, and the `README.md` clearly states:  *We recommend always using the newest stable release of Go.* ;)