### PR TITLE
Add go_sdk_version parameter

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -9,9 +9,9 @@ load(
     "go_repository",
 )
 
-def jsonnet_go_dependencies():
+def jsonnet_go_dependencies(go_sdk_version = "host"):
     go_rules_dependencies()
-    go_register_toolchains(version = "host")
+    go_register_toolchains(version = go_sdk_version)
     gazelle_dependencies()
     go_repository(
         name = "com_github_davecgh_go_spew",


### PR DESCRIPTION
Adds a `go_sdk_version` to register a specific Go toolchain.

Motivation for the change is here: https://github.com/bazelbuild/rules_jsonnet/pull/153