### PR TITLE
fix: no panic with negative index to std.substr

### DIFF
--- a/builtins.go
+++ b/builtins.go
@@ -991,6 +991,11 @@ func builtinSubstr(i *interpreter, inputStr, inputFrom, inputLen value) (value, 
 		return nil, makeRuntimeError(msg, i.getCurrentStackTrace())
 	}
 
+	if fromV.value < 0 {
+		msg := fmt.Sprintf("substr second parameter should be greater than zero, got %f", fromV.value)
+		return nil, makeRuntimeError(msg, i.getCurrentStackTrace())
+	}
+
 	lenV, err := i.getNumber(inputLen)
 	if err != nil {
 		msg := fmt.Sprintf("substr third parameter should be a number, got %s", inputLen.getType().name)


### PR DESCRIPTION
As mentioned in #570.

The approach here is similar to the [cpp implementation](https://github.com/google/jsonnet/blob/master/core/vm.cpp#L1494) of `jsonnet`, we catch the problem early and inform the user with a sensible message, as opposed to a large panic stacktrace being shown.