### PR TITLE
Fix Bazel setup to allow building from external repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ bazel run //:gazelle
 To use `go-jsonnet` from a different Bazel workspace, add the repository
 and its dependencies to your WORKSPACE file.
 
-You will also need to register a Go toolchain.
+You will also need to register a Go toolchain (unless you already have one).
 
 It should look like this:
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Additionally if any files were moved around, see the section [Keeping the Bazel 
 ## Building libjsonnet.wasm
 
 ```bash
-GOOS=js GOARCH=wasm go build -o libjsonnet.wasm ./cmd/wasm 
+GOOS=js GOARCH=wasm go build -o libjsonnet.wasm ./cmd/wasm
 ```
 
 Or if using bazel:
@@ -233,4 +233,38 @@ bazel run //:gazelle -- update-repos -from_file=go.mod -to_macro=bazel/deps.bzl%
 Similarly, after adding or removing Go source files, it may be necessary to synchronize the Bazel rules by running the following command:
 ```bash
 bazel run //:gazelle
+```
+
+## Using this repository from other Bazel workspaces
+
+To use `go-jsonnet` from a different Bazel workspace, add the repository
+and its dependencies to your WORKSPACE file.
+
+You will also need to register a Go toolchain.
+
+It should look like this:
+
+```
+JSONNET_VERSION = 0.18.0
+http_archive(
+	name = "jsonnet_go",
+    urls = [
+		"https://github.com/google/go-jsonnet/archive/v{version}.tar.gz".format(version = JSONNET_VERSION),
+    ],
+    strip_prefix = "go-jsonnet-{version}".format(version = JSONNET_VERSION),
+    sha256 = "369af561550ba8cff5dd7dd08a771805a38d795da3285221012cf3a2933b363e",
+)
+
+load("@jsonnet_go//bazel:repositories.bzl", "jsonnet_go_repositories")
+
+jsonnet_go_repositories()
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains")
+
+go_register_toolchains(version = "1.18")
+
+load("@jsonnet_go//bazel:deps.bzl", "jsonnet_go_dependencies")
+
+jsonnet_go_dependencies()
+
 ```

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,6 +7,10 @@ load(
 
 jsonnet_go_repositories()
 
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains")
+
+go_register_toolchains(version = "host")
+
 load(
     "@google_jsonnet_go//bazel:deps.bzl",
     "jsonnet_go_dependencies",

--- a/ast/BUILD.bazel
+++ b/ast/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -12,4 +12,10 @@ go_library(
     ],
     importpath = "github.com/google/go-jsonnet/ast",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["util_test.go"],
+    embed = [":go_default_library"],
 )

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -1,17 +1,12 @@
 load(
-    "@io_bazel_rules_go//go:deps.bzl",
-    "go_register_toolchains",
-    "go_rules_dependencies",
-)
-load(
     "@bazel_gazelle//:deps.bzl",
     "gazelle_dependencies",
     "go_repository",
 )
+load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies")
 
-def jsonnet_go_dependencies(go_sdk_version = "host"):
+def jsonnet_go_dependencies():
     go_rules_dependencies()
-    go_register_toolchains(version = go_sdk_version)
     gazelle_dependencies()
     go_repository(
         name = "com_github_davecgh_go_spew",

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -7,6 +7,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies")
 
 def jsonnet_go_dependencies():
     go_rules_dependencies()
+    go_register_toolchains()
     gazelle_dependencies()
     go_repository(
         name = "com_github_davecgh_go_spew",

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -3,8 +3,20 @@ load(
     "http_archive",
 )
 
+def _maybe(repo_rule, name, **kwargs):
+    """Executes the given repository rule if it hasn't been executed already.
+    Args:
+      repo_rule: The repository rule to be executed (e.g.,
+          `native.git_repository`.)
+      name: The name of the repository to be defined by the rule.
+      **kwargs: Additional arguments passed directly to the repository rule.
+    """
+    if not native.existing_rule(name):
+        repo_rule(name = name, **kwargs)
+
 def jsonnet_go_repositories():
-    http_archive(
+    _maybe(
+        http_archive,
         name = "io_bazel_rules_go",
         sha256 = "7904dbecbaffd068651916dce77ff3437679f9d20e1a7956bff43826e7645fcc",
         urls = [
@@ -13,7 +25,8 @@ def jsonnet_go_repositories():
         ],
     )
 
-    http_archive(
+    _maybe(
+        http_archive,
         name = "bazel_gazelle",
         sha256 = "222e49f034ca7a1d1231422cdb67066b885819885c356673cb1f72f748a3c9d4",
         urls = [
@@ -21,7 +34,9 @@ def jsonnet_go_repositories():
             "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.3/bazel-gazelle-v0.22.3.tar.gz",
         ],
     )
-    http_archive(
+
+    _maybe(
+        http_archive,
         name = "cpp_jsonnet",
         sha256 = "82d3cd35de8ef230d094b60a30e7659f415c350b0aa2bd62162cf2afdf163959",
         strip_prefix = "jsonnet-90cad75dcc2eafdcf059c901169d36539dc8a699",

--- a/c-bindings/BUILD.bazel
+++ b/c-bindings/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
     deps = [
         "//:go_default_library",
         "//ast:go_default_library",
+        "//formatter:go_default_library",
     ],
 )
 

--- a/cmd/wasm/BUILD.bazel
+++ b/cmd/wasm/BUILD.bazel
@@ -2,15 +2,16 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "main.go",
-    ],
+    srcs = ["main.go"],
     importpath = "github.com/google/go-jsonnet/cmd/wasm",
     visibility = ["//visibility:private"],
-    deps = [
-        "//:go_default_library",
-        "//internal/formatter:go_default_library",
-    ],
+    deps = select({
+        "@io_bazel_rules_go//go/platform:js_wasm": [
+            "//:go_default_library",
+            "//internal/formatter:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 go_binary(

--- a/linter/BUILD.bazel
+++ b/linter/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//linter/internal/common:go_default_library",
         "//linter/internal/traversal:go_default_library",
         "//linter/internal/types:go_default_library",
-        "//linter/internal/utils:go_default_library",
         "//linter/internal/variables:go_default_library",
     ],
 )

--- a/linter/internal/common/BUILD.bazel
+++ b/linter/internal/common/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["common.go"],
     importpath = "github.com/google/go-jsonnet/linter/internal/common",
     visibility = ["//linter:__subpackages__"],
-    deps = ["//ast:go_default_library"],
+    deps = [
+        "//ast:go_default_library",
+        "//internal/errors:go_default_library",
+    ],
 )

--- a/linter/internal/traversal/BUILD.bazel
+++ b/linter/internal/traversal/BUILD.bazel
@@ -8,6 +8,6 @@ go_library(
     deps = [
         "//ast:go_default_library",
         "//internal/parser:go_default_library",
-        "//linter/internal/utils:go_default_library",
+        "//linter/internal/common:go_default_library",
     ],
 )

--- a/linter/internal/types/BUILD.bazel
+++ b/linter/internal/types/BUILD.bazel
@@ -18,6 +18,5 @@ go_library(
         "//ast:go_default_library",
         "//internal/parser:go_default_library",
         "//linter/internal/common:go_default_library",
-        "//linter/internal/utils:go_default_library",
     ],
 )


### PR DESCRIPTION
When loading this repo from another Bazel workspace we get the following error.
```
ERROR: Traceback (most recent call last):
        File "/Users/paulsmsm/cognite/infrastructure/WORKSPACE", line 447, column 14, in <toplevel>
                jsonnet_repos()
        File "/Users/paulsmsm/cognite/infrastructure/tools/jsonnet/repos.bzl", line 8, column 28, in jsonnet_repos
                jsonnet_go_dependencies()
        File "/private/var/tmp/_bazel_paulsmsm/d6487c682645eb55f96a41598d44250b/external/jsonnet_go/bazel/deps.bzl", line 14, column 27, in jsonnet_go_dependencies
                go_register_toolchains(version = "host")
        File "/private/var/tmp/_bazel_paulsmsm/d6487c682645eb55f96a41598d44250b/external/io_bazel_rules_go/go/private/sdk.bzl", line 458, column 13, in go_register_toolchains
                fail("go_register_toolchains: version set after go sdk rule declared ({})".format(", ".join([r["name"] for r in sdk_rules])))
Error in fail: go_register_toolchains: version set after go sdk rule declared (go_sdk)
```
If a repo is already using Go they have probably already defined a Go toolchain, so it's not necessary to declare that as a dependency of go-jsonnet. I have moved the toolchain registration to the WORKSPACE in order to fix this.

I have also executed `bazel run gazelle` which made lots of changes to BUILD files.