### PR TITLE
Update deps.bzl

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -24,6 +24,7 @@ def jsonnet_go_dependencies(go_sdk_version = "host"):
         importpath = "github.com/fatih/color",
         sum = "h1:mRhaKNwANqRgUBGKmnI5ZxEk7QXmjQeCcuYFMX2bfcc=",
         version = "v1.12.0",
+        build_external = "external",
     )
 
     go_repository(
@@ -49,12 +50,14 @@ def jsonnet_go_dependencies(go_sdk_version = "host"):
         importpath = "github.com/mattn/go-colorable",
         sum = "h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=",
         version = "v0.1.8",
+        build_external = "external",
     )
     go_repository(
         name = "com_github_mattn_go_isatty",
         importpath = "github.com/mattn/go-isatty",
         sum = "h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=",
         version = "v0.0.12",
+        build_external = "external",
     )
     go_repository(
         name = "com_github_pmezard_go_difflib",


### PR DESCRIPTION
Fixes an issue reported in https://github.com/bazelbuild/rules_jsonnet/issues/125 where `com_github_fatih_color` does not specify its deps.

setting `build_external` to `external` allows bazel to call out to resolve imports. see https://github.com/bazelbuild/bazel-gazelle/blob/master/repository.md#go_repository