### PR TITLE
handle int type in interpreter

### DIFF
--- a/interpreter.go
+++ b/interpreter.go
@@ -952,6 +952,8 @@ func jsonToValue(i *interpreter, v interface{}) (value, error) {
 		return makeValueBoolean(v), nil
 	case float64:
 		return makeDoubleCheck(i, v)
+	case int:
+		return makeDoubleCheck(i, float64(v))
 
 	case map[string]interface{}:
 		fieldMap := map[string]value{}

--- a/main_test.go
+++ b/main_test.go
@@ -96,6 +96,22 @@ var nativeError = &NativeFunction{
 	},
 }
 
+var jsonToValueRegr = &NativeFunction{
+	Name:   "jsonToValueRegr",
+	Params: ast.Identifiers{},
+	Func: func(_ []interface{}) (interface{}, error) {
+		m := make(map[string]interface{})
+		m["null"] = nil
+		m["array"] = []interface{}{"foo", "bar"}
+		m["boolean"] = true
+		m["float"] = 1.2
+		m["int"] = 1
+		m["object"] = map[string]interface{}{"key": "val"}
+		m["string"] = "string"
+		return m, nil
+	},
+}
+
 type jsonnetInput struct {
 	name             string
 	input            []byte
@@ -136,6 +152,7 @@ func runInternalJsonnet(i jsonnetInput) jsonnetResult {
 
 	vm.NativeFunction(jsonToString)
 	vm.NativeFunction(nativeError)
+	vm.NativeFunction(jsonToValueRegr)
 
 	rawAST, _, staticErr := parser.SnippetToRawAST(ast.DiagnosticFileName(i.name), "", string(i.input))
 	if staticErr != nil {

--- a/testdata/native_jsonToValueRegr.golden
+++ b/testdata/native_jsonToValueRegr.golden
@@ -1,0 +1,14 @@
+{
+  "array": [
+    "foo",
+    "bar"
+  ],
+  "boolean": true,
+  "float": 1.2,
+  "int": 1,
+  "null": null,
+  "object": {
+    "key": "val"
+  },
+  "string": "string"
+}

--- a/testdata/native_jsonToValueRegr.jsonnet
+++ b/testdata/native_jsonToValueRegr.jsonnet
@@ -1,0 +1,1 @@
+std.native("jsonToValueRegr")


### PR DESCRIPTION
This PR adds support for `int` types in the interpreter. I ran into the need for this when attempting to evaluate a jsonnet file with input un-marshaled from YAML. 

YAML has support for `Integer` as a base type where JSON's numeric type is always a float.