### PR TITLE
feat: Report native function panics as runtime errors.

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -96,6 +96,14 @@ var nativeError = &NativeFunction{
 	},
 }
 
+var nativePanic = &NativeFunction{
+	Name:   "nativePanic",
+	Params: ast.Identifiers{},
+	Func: func(x []interface{}) (interface{}, error) {
+		panic("native function panic")
+	},
+}
+
 type jsonnetInput struct {
 	name             string
 	input            []byte
@@ -136,6 +144,7 @@ func runInternalJsonnet(i jsonnetInput) jsonnetResult {
 
 	vm.NativeFunction(jsonToString)
 	vm.NativeFunction(nativeError)
+	vm.NativeFunction(nativePanic)
 
 	rawAST, _, staticErr := parser.SnippetToRawAST(ast.DiagnosticFileName(i.name), "", string(i.input))
 	if staticErr != nil {

--- a/testdata/native_panic.golden
+++ b/testdata/native_panic.golden
@@ -1,0 +1,10 @@
+RUNTIME ERROR: native function "nativePanic" panicked: native function panic
+-------------------------------------------------
+	testdata/native_panic:1:1-28	$
+
+std.native("nativePanic")()
+
+-------------------------------------------------
+	During evaluation	
+
+

--- a/testdata/native_panic.jsonnet
+++ b/testdata/native_panic.jsonnet
@@ -1,0 +1,1 @@
+std.native("nativePanic")()

--- a/thunks.go
+++ b/thunks.go
@@ -17,6 +17,7 @@ limitations under the License.
 package jsonnet
 
 import (
+	"fmt"
 	"github.com/google/go-jsonnet/ast"
 )
 
@@ -273,7 +274,15 @@ func (native *NativeFunction) evalCall(arguments callArguments, i *interpreter) 
 		}
 		nativeArgs = append(nativeArgs, json)
 	}
-	resultJSON, err := native.Func(nativeArgs)
+	call := func() (resultJSON interface{}, err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("native function %#v panicked: %v", native.Name, r)
+			}
+		}()
+		return native.Func(nativeArgs)
+	}
+	resultJSON, err := call()
 	if err != nil {
 		return nil, i.Error(err.Error())
 	}


### PR DESCRIPTION
Previously, you'd get an "INTERNAL ERROR: (CRASH)" with a full backtrace
and a link to file a bug against go-jsonnet.