### PR TITLE
Add context.Context-aware variants of vm.Evaluate* methods, honor the context during evaluation and manifestation.

### DIFF
--- a/error_formatter.go
+++ b/error_formatter.go
@@ -18,6 +18,7 @@ package jsonnet
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 
@@ -27,7 +28,7 @@ import (
 
 // An ErrorFormatter formats errors with stacktraces and color.
 type ErrorFormatter interface {
-	// Format static, runtime, and unexpected errors prior to printing them.
+	// Format static, runtime, context, and unexpected errors prior to printing them.
 	Format(err error) string
 
 	// Set the the maximum length of stack trace before cropping.
@@ -63,6 +64,10 @@ func (ef *termErrorFormatter) SetColorFormatter(color ColorFormatter) {
 }
 
 func (ef *termErrorFormatter) Format(err error) string {
+	switch err {
+	case context.Canceled, context.DeadlineExceeded:
+		return err.Error()
+	}
 	switch err := err.(type) {
 	case RuntimeError:
 		return ef.formatRuntime(&err)

--- a/interpreter.go
+++ b/interpreter.go
@@ -1237,26 +1237,6 @@ func buildObject(hide ast.ObjectFieldHide, fields map[string]value) *valueObject
 	return makeValueSimpleObject(bindingFrame{}, fieldMap, nil, nil)
 }
 
-func buildInterpreter(ext vmExtMap, nativeFuncs map[string]*NativeFunction, maxStack int, ic *importCache, traceOut io.Writer) (*interpreter, error) {
-	i := interpreter{
-		stack:       makeCallStack(maxStack),
-		importCache: ic,
-		traceOut:    traceOut,
-		nativeFuncs: nativeFuncs,
-	}
-
-	stdObj, err := buildStdObject(&i)
-	if err != nil {
-		return nil, err
-	}
-
-	i.baseStd = stdObj
-
-	i.extVars = prepareExtVars(&i, ext, "extvar")
-
-	return &i, nil
-}
-
 func makeInitialEnv(filename string, baseStd *valueObject) environment {
 	fileSpecific := buildObject(ast.ObjectFieldHidden, map[string]value{
 		"thisFile": makeValueString(filename),
@@ -1313,15 +1293,7 @@ func evaluateAux(i *interpreter, node ast.Node, tla vmExtMap) (value, error) {
 	return result, nil
 }
 
-// TODO(sbarzowski) this function takes far too many arguments - build interpreter in vm instead
-func evaluate(node ast.Node, ext vmExtMap, tla vmExtMap, nativeFuncs map[string]*NativeFunction,
-	maxStack int, ic *importCache, traceOut io.Writer, stringOutputMode bool) (string, error) {
-
-	i, err := buildInterpreter(ext, nativeFuncs, maxStack, ic, traceOut)
-	if err != nil {
-		return "", err
-	}
-
+func evaluate(i *interpreter, node ast.Node, tla vmExtMap, stringOutputMode bool) (string, error) {
 	result, err := evaluateAux(i, node, tla)
 	if err != nil {
 		return "", err
@@ -1342,15 +1314,7 @@ func evaluate(node ast.Node, ext vmExtMap, tla vmExtMap, nativeFuncs map[string]
 	return buf.String(), nil
 }
 
-// TODO(sbarzowski) this function takes far too many arguments - build interpreter in vm instead
-func evaluateMulti(node ast.Node, ext vmExtMap, tla vmExtMap, nativeFuncs map[string]*NativeFunction,
-	maxStack int, ic *importCache, traceOut io.Writer, stringOutputMode bool) (map[string]string, error) {
-
-	i, err := buildInterpreter(ext, nativeFuncs, maxStack, ic, traceOut)
-	if err != nil {
-		return nil, err
-	}
-
+func evaluateMulti(i *interpreter, node ast.Node, tla vmExtMap, stringOutputMode bool) (map[string]string, error) {
 	result, err := evaluateAux(i, node, tla)
 	if err != nil {
 		return nil, err
@@ -1362,15 +1326,7 @@ func evaluateMulti(node ast.Node, ext vmExtMap, tla vmExtMap, nativeFuncs map[st
 	return manifested, err
 }
 
-// TODO(sbarzowski) this function takes far too many arguments - build interpreter in vm instead
-func evaluateStream(node ast.Node, ext vmExtMap, tla vmExtMap, nativeFuncs map[string]*NativeFunction,
-	maxStack int, ic *importCache, traceOut io.Writer) ([]string, error) {
-
-	i, err := buildInterpreter(ext, nativeFuncs, maxStack, ic, traceOut)
-	if err != nil {
-		return nil, err
-	}
-
+func evaluateStream(i *interpreter, node ast.Node, tla vmExtMap) ([]string, error) {
 	result, err := evaluateAux(i, node, tla)
 	if err != nil {
 		return nil, err

--- a/main_test.go
+++ b/main_test.go
@@ -18,6 +18,7 @@ package jsonnet
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -165,7 +166,7 @@ func runInternalJsonnet(i jsonnetInput) jsonnetResult {
 	testChildren(desugaredAST)
 
 	// TODO(sbarzowski) We should treat the tests as anonymous snippets or import them with an importer.
-	rawOutput, err := vm.evaluateSnippet(ast.DiagnosticFileName(i.name), i.name, string(i.input), i.eKind)
+	rawOutput, err := vm.evaluateSnippet(context.Background(), ast.DiagnosticFileName(i.name), i.name, string(i.input), i.eKind)
 	switch {
 	case err != nil:
 		// TODO(sbarzowski) perhaps somehow mark that we are processing


### PR DESCRIPTION
The idea here is to be able to put some upper limit on the time it takes to process a jsonnet file (or any other piece of code). Previously, the best bet was to fork+exec with a timeout.

Please review this commit-by-commit:
 - the first one just mechanically moves arguments around (this was a TODO, I hope I got the idea right)
 - the second adds the methods and the context checks

The added test verifies that the manifestation respects the context, I don't have an idea about how to test the evaluation case. I'll be grateful for any hints :)
