### PR TITLE
Don't pass version to `go_register_toolchains()` by default

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -9,9 +9,12 @@ load(
     "go_repository",
 )
 
-def jsonnet_go_dependencies(go_sdk_version = "host"):
+def jsonnet_go_dependencies(go_sdk_version = None):
     go_rules_dependencies()
-    go_register_toolchains(version = go_sdk_version)
+    if go_sdk_version != None:
+        go_register_toolchains(version = go_sdk_version)
+    else:
+        go_register_toolchains()
     gazelle_dependencies()
     go_repository(
         name = "com_github_davecgh_go_spew",


### PR DESCRIPTION
This should fix #619 where `jsonnet_go_dependencies()` fails because a go toolchain has already been registered.