### PR TITLE
feat: add support to the jsonnet linter for std.manifestJsonMinified

### DIFF
--- a/linter/internal/types/stdlib.go
+++ b/linter/internal/types/stdlib.go
@@ -105,14 +105,15 @@ func prepareStdlib(g *typeGraph) {
 
 		// Manifestation
 
-		"manifestIni":        g.newSimpleFuncType(stringType, "ini"),
-		"manifestPython":     g.newSimpleFuncType(stringType, "v"),
-		"manifestPythonVars": g.newSimpleFuncType(stringType, "conf"),
-		"manifestTomlEx":     g.newSimpleFuncType(stringType, "value", "indent"),
-		"manifestJsonEx":     g.newSimpleFuncType(stringType, "value", "indent"),
-		"manifestYamlDoc":    g.newSimpleFuncType(stringType, "value"),
-		"manifestYamlStream": g.newSimpleFuncType(stringType, "value"),
-		"manifestXmlJsonml":  g.newSimpleFuncType(stringType, "value"),
+		"manifestIni":          g.newSimpleFuncType(stringType, "ini"),
+		"manifestPython":       g.newSimpleFuncType(stringType, "v"),
+		"manifestPythonVars":   g.newSimpleFuncType(stringType, "conf"),
+		"manifestTomlEx":       g.newSimpleFuncType(stringType, "value", "indent"),
+		"manifestJsonEx":       g.newSimpleFuncType(stringType, "value", "indent"),
+		"manifestJsonMinified": g.newSimpleFuncType(stringType, "value"),
+		"manifestYamlDoc":      g.newSimpleFuncType(stringType, "value"),
+		"manifestYamlStream":   g.newSimpleFuncType(stringType, "value"),
+		"manifestXmlJsonml":    g.newSimpleFuncType(stringType, "value"),
 
 		// Arrays
 

--- a/testdata/stdlib_smoke_test.golden
+++ b/testdata/stdlib_smoke_test.golden
@@ -106,6 +106,7 @@
    ],
    "manifestIni": "a = 1\nb = 2\n[s1]\nx = 1\ny = 2\n",
    "manifestJsonEx": "{\n \"a\": {\n  \"b\": \"c\"\n }\n}",
+   "manifestJsonMinified": "{\"a\":{\"b\":\"c\"}}",
    "manifestPython": "{\"a\": {\"b\": \"c\"}}",
    "manifestPythonVars": "a = {\"b\": \"c\"}\n",
    "manifestTomlEx": "\n\n[a]\n b = \"c\"",

--- a/testdata/stdlib_smoke_test.jsonnet
+++ b/testdata/stdlib_smoke_test.jsonnet
@@ -95,6 +95,7 @@
     manifestPythonVars: std.manifestPythonVars(conf={a: {b: "c"}}),
     manifestTomlEx: std.manifestTomlEx(value={a: {b: "c"}}, indent=" "),
     manifestJsonEx: std.manifestJsonEx(value={a: {b: "c"}}, indent=" "),
+    manifestJsonMinified: std.manifestJsonMinified(value={a: {b: "c"}}),
     manifestYamlDoc: std.manifestYamlDoc(value={a: {b: "c"}}),
     manifestYamlStream: std.manifestYamlStream(value=[42, {a: {b: "c"}}]),
     manifestXmlJsonml:  std.manifestXmlJsonml(value=["blah", {a: 42}]),


### PR DESCRIPTION
Adds support for the `std.manifestJsonMinified` to the linter

Helps #610