### PR TITLE
fix FileImporter not work on windows

### DIFF
--- a/imports.go
+++ b/imports.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"unsafe"
 
 	"github.com/google/go-jsonnet/ast"
@@ -231,10 +231,10 @@ func (importer *FileImporter) tryPath(dir, importedPath string) (found bool, con
 		importer.fsCache = make(map[string]*fsCacheEntry)
 	}
 	var absPath string
-	if path.IsAbs(importedPath) {
+	if filepath.IsAbs(importedPath) {
 		absPath = importedPath
 	} else {
-		absPath = path.Join(dir, importedPath)
+		absPath = filepath.Join(dir, importedPath)
 	}
 	var entry *fsCacheEntry
 	if cacheEntry, isCached := importer.fsCache[absPath]; isCached {
@@ -267,7 +267,7 @@ func (importer *FileImporter) Import(importedFrom, importedPath string) (content
 	// in the importer.
 	// We need to relativize the paths in the error formatter, so that the stack traces
 	// don't have ugly absolute paths (less readable and messy with golden tests).
-	dir, _ := path.Split(importedFrom)
+	dir, _ := filepath.Split(importedFrom)
 	found, content, foundHere, err := importer.tryPath(dir, importedPath)
 	if err != nil {
 		return Contents{}, "", err


### PR DESCRIPTION
FileImporter should use "path/filepath" not use "path".
package "path" will not work properly on non-*nix systems, such as windows