### PR TITLE
perf: add size hint to map creation

### DIFF
--- a/ast/identifier_set.go
+++ b/ast/identifier_set.go
@@ -13,7 +13,7 @@ type IdentifierSet map[Identifier]struct{}
 
 // NewIdentifierSet creates and returns a reference to an empty set.
 func NewIdentifierSet(a ...Identifier) IdentifierSet {
-	s := make(IdentifierSet)
+	s := make(IdentifierSet, len(a))
 	for _, i := range a {
 		s.Add(i)
 	}

--- a/builtins.go
+++ b/builtins.go
@@ -1386,7 +1386,7 @@ type builtin interface {
 }
 
 func flattenArgs(args callArguments, params []namedParameter, defaults []value) []*cachedThunk {
-	positions := make(map[ast.Identifier]int)
+	positions := make(map[ast.Identifier]int, len(params))
 	for i, param := range params {
 		positions[param.name] = i
 	}
@@ -1606,7 +1606,7 @@ var uopBuiltins = []*unaryBuiltin{
 }
 
 func buildBuiltinMap(builtins []builtin) map[string]evalCallable {
-	result := make(map[string]evalCallable)
+	result := make(map[string]evalCallable, len(builtins))
 	for _, b := range builtins {
 		result[string(b.Name())] = b
 	}

--- a/interpreter.go
+++ b/interpreter.go
@@ -226,7 +226,7 @@ func (s *callStack) getCurrentEnv(ast ast.Node) environment {
 
 // Build a binding frame containing specified variables.
 func (s *callStack) capture(freeVars ast.Identifiers) bindingFrame {
-	env := make(bindingFrame)
+	env := make(bindingFrame, len(freeVars))
 	for _, fv := range freeVars {
 		env[fv] = s.lookUpVarOrPanic(fv)
 	}
@@ -265,7 +265,7 @@ type interpreter struct {
 
 // Map union, b takes precedence when keys collide.
 func addBindings(a, b bindingFrame) bindingFrame {
-	result := make(bindingFrame)
+	result := make(bindingFrame, len(a))
 
 	for k, v := range a {
 		result[k] = v
@@ -390,7 +390,7 @@ func (i *interpreter) evaluate(a ast.Node, tc tailCallStatus) (value, error) {
 
 	case *ast.DesugaredObject:
 		// Evaluate all the field names.  Check for null, dups, etc.
-		fields := make(simpleObjectFieldMap)
+		fields := make(simpleObjectFieldMap, len(node.Fields))
 		for _, field := range node.Fields {
 			fieldNameValue, err := i.evaluate(field.Name, nonTailCall)
 			if err != nil {
@@ -512,7 +512,7 @@ func (i *interpreter) evaluate(a ast.Node, tc tailCallStatus) (value, error) {
 		return makeValueString(node.Value), nil
 
 	case *ast.Local:
-		vars := make(bindingFrame)
+		vars := make(bindingFrame, len(node.Binds))
 		bindEnv := i.stack.getCurrentEnv(a)
 		for _, bind := range node.Binds {
 			th := cachedThunk{env: &bindEnv, body: bind.Body}
@@ -724,7 +724,7 @@ func (i *interpreter) manifestJSON(v value) (interface{}, error) {
 		}
 		i.stack.clearCurrentTrace()
 
-		result := make(map[string]interface{})
+		result := make(map[string]interface{}, len(fieldNames))
 
 		for _, fieldName := range fieldNames {
 			msg := ast.MakeLocationRangeMessage(fmt.Sprintf("Field %#v", fieldName))

--- a/thunks.go
+++ b/thunks.go
@@ -110,7 +110,7 @@ type bindingsUnboundField struct {
 }
 
 func (f *bindingsUnboundField) evaluate(i *interpreter, sb selfBinding, origBindings bindingFrame, fieldName string) (value, error) {
-	upValues := make(bindingFrame)
+	upValues := make(bindingFrame, len(origBindings)+len(f.bindings))
 	for variable, pvalue := range origBindings {
 		upValues[variable] = pvalue
 	}
@@ -192,7 +192,7 @@ func forceThunks(i *interpreter, args *bindingFrame) error {
 }
 
 func (closure *closure) evalCall(arguments callArguments, i *interpreter) (value, error) {
-	argThunks := make(bindingFrame)
+	argThunks := make(bindingFrame, len(arguments.named)+len(arguments.positional))
 	parameters := closure.parameters()
 	for i, arg := range arguments.positional {
 		argThunks[parameters[i].name] = arg

--- a/value.go
+++ b/value.go
@@ -354,22 +354,22 @@ func (f *valueFunction) parameters() []namedParameter {
 }
 
 func checkArguments(i *interpreter, args callArguments, params []namedParameter) error {
-
-	numPassed := len(args.positional)
+	numPositional := len(args.positional)
+	numNamed := len(args.named)
 	maxExpected := len(params)
 
-	if numPassed > maxExpected {
-		return i.Error(fmt.Sprintf("function expected %v positional argument(s), but got %v", maxExpected, numPassed))
+	if numPositional > maxExpected {
+		return i.Error(fmt.Sprintf("function expected %v positional argument(s), but got %v", maxExpected, numPositional))
 	}
 
 	// Parameter names the function will accept.
-	accepted := make(map[ast.Identifier]bool)
+	accepted := make(map[ast.Identifier]bool, maxExpected)
 	for _, param := range params {
 		accepted[param.name] = true
 	}
 
 	// Parameter names the call will bind.
-	received := make(map[ast.Identifier]bool)
+	received := make(map[ast.Identifier]bool, numPositional+numNamed)
 	for i := range args.positional {
 		received[params[i].name] = true
 	}
@@ -681,7 +681,7 @@ func findField(curr uncachedObject, minSuperDepth int, f string) (bool, simpleOb
 }
 
 func prepareFieldUpvalues(sb selfBinding, upValues bindingFrame, locals []objectLocal) bindingFrame {
-	newUpValues := make(bindingFrame)
+	newUpValues := make(bindingFrame, len(upValues))
 	for k, v := range upValues {
 		newUpValues[k] = v
 	}


### PR DESCRIPTION
Hey folks, just a small patch to add size hints to maps where it seemed appropriate. I'm not sure if I'm missing an obvious reason these were left out initially. But given `go-jsonnets` use of maps this could be a low hanging fruit for cutting down on allocations.