### PR TITLE
c-bindings: Add jsonnet_realloc export

### DIFF
--- a/c-bindings/c-bindings.go
+++ b/c-bindings/c-bindings.go
@@ -663,5 +663,11 @@ func jsonnet_set_trace_out_callback(vmRef *C.struct_JsonnetVm, cb *C.JsonnetIoWr
 	vm.SetTraceOut(&traceOut{cb})
 }
 
+//export jsonnet_realloc
+func jsonnet_realloc(vmRef *C.struct_JsonnetVm, buf *C.char, sz C.size_t) *C.char {
+	return C.jsonnet_internal_realloc(vmRef, buf, sz)
+}
+
+
 func main() {
 }

--- a/c-bindings/internal.h
+++ b/c-bindings/internal.h
@@ -46,3 +46,5 @@ int jsonnet_internal_execute_writer(JsonnetIoWriterCallback *cb,
                                     int *success);
 
 void jsonnet_internal_free_string(char *str);
+
+char* jsonnet_internal_realloc(struct JsonnetVm *vm, char *str, size_t sz);

--- a/c-bindings/libjsonnet.cpp
+++ b/c-bindings/libjsonnet.cpp
@@ -72,7 +72,7 @@ static void memory_panic(void)
     abort();
 }
 
-char *jsonnet_realloc(JsonnetVm *vm, char *str, size_t sz)
+char *jsonnet_internal_realloc(JsonnetVm *vm, char *str, size_t sz)
 {
     (void)vm;
     if (str == nullptr) {


### PR DESCRIPTION
This adds the realloc function as an export in c-bindings.go so that it is included in the generated header and can be used by dependent libraries. No implementation details changed, just the piping for exporting the function.

Tested manually by using the exported function in another binary.

Addresses #562