### PR TITLE
Fix jsonnet-lint bazel build

### DIFF
--- a/linter/BUILD.bazel
+++ b/linter/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//linter/internal/common:go_default_library",
         "//linter/internal/traversal:go_default_library",
         "//linter/internal/types:go_default_library",
-        "//linter/internal/utils:go_default_library",
         "//linter/internal/variables:go_default_library",
     ],
 )

--- a/linter/internal/common/BUILD.bazel
+++ b/linter/internal/common/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["common.go"],
     importpath = "github.com/google/go-jsonnet/linter/internal/common",
     visibility = ["//linter:__subpackages__"],
-    deps = ["//ast:go_default_library"],
+    deps = [
+        "//ast:go_default_library",
+        "//internal/errors:go_default_library",
+    ],
 )

--- a/linter/internal/traversal/BUILD.bazel
+++ b/linter/internal/traversal/BUILD.bazel
@@ -8,6 +8,6 @@ go_library(
     deps = [
         "//ast:go_default_library",
         "//internal/parser:go_default_library",
-        "//linter/internal/utils:go_default_library",
+        "//linter/internal/common:go_default_library",
     ],
 )

--- a/linter/internal/types/BUILD.bazel
+++ b/linter/internal/types/BUILD.bazel
@@ -18,6 +18,5 @@ go_library(
         "//ast:go_default_library",
         "//internal/parser:go_default_library",
         "//linter/internal/common:go_default_library",
-        "//linter/internal/utils:go_default_library",
     ],
 )


### PR DESCRIPTION
Update BUILD.bazel files so `bazel build //cmd/jsonnet-lint` works
again.