### PR TITLE
Fix //c-bindings bazel build

### DIFF
--- a/c-bindings/BUILD.bazel
+++ b/c-bindings/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
     deps = [
         "//:go_default_library",
         "//ast:go_default_library",
+        "//formatter:go_default_library",
     ],
 )
 


### PR DESCRIPTION
Add missing bazel dependency so `bazel build //c-bindings` works again.