### PR TITLE
Update bazel cpp_jsonnet reference to match git submodule

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -3,6 +3,10 @@ load(
     "http_archive",
 )
 
+# NB: update_cpp_jsonnet.sh looks for these.
+CPP_JSONNET_SHA256 = "82d3cd35de8ef230d094b60a30e7659f415c350b0aa2bd62162cf2afdf163959"
+CPP_JSONNET_GITHASH = "90cad75dcc2eafdcf059c901169d36539dc8a699"
+
 def jsonnet_go_repositories():
     http_archive(
         name = "io_bazel_rules_go",
@@ -23,7 +27,7 @@ def jsonnet_go_repositories():
     )
     http_archive(
         name = "cpp_jsonnet",
-        sha256 = "82d3cd35de8ef230d094b60a30e7659f415c350b0aa2bd62162cf2afdf163959",
-        strip_prefix = "jsonnet-90cad75dcc2eafdcf059c901169d36539dc8a699",
-        urls = ["https://github.com/google/jsonnet/archive/90cad75dcc2eafdcf059c901169d36539dc8a699.tar.gz"],
+        sha256 = CPP_JSONNET_SHA256,
+        strip_prefix = "jsonnet-%s" % CPP_JSONNET_GITHASH,
+        urls = ["https://github.com/google/jsonnet/archive/%s.tar.gz" % CPP_JSONNET_GITHASH],
     )

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -4,8 +4,8 @@ load(
 )
 
 # NB: update_cpp_jsonnet.sh looks for these.
-CPP_JSONNET_SHA256 = "82d3cd35de8ef230d094b60a30e7659f415c350b0aa2bd62162cf2afdf163959"
-CPP_JSONNET_GITHASH = "90cad75dcc2eafdcf059c901169d36539dc8a699"
+CPP_JSONNET_SHA256 = "867fe09842e9868c95d57c19648674241a83c581a780ab4f4a5a37ac2afb06be"
+CPP_JSONNET_GITHASH = "34419d2483927ceb17cd506cad77c3c2a96e7b8c"
 
 def jsonnet_go_repositories():
     http_archive(

--- a/update_cpp_jsonnet.sh
+++ b/update_cpp_jsonnet.sh
@@ -8,8 +8,19 @@ set -x
 cd cpp-jsonnet
 git checkout master
 git pull
+hash=$(git rev-parse HEAD)
 cd ..
 go run cmd/dumpstdlibast/dumpstdlibast.go cpp-jsonnet/stdlib/std.jsonnet > astgen/stdast.go
+
+sha256=$(curl -fL https://github.com/google/jsonnet/archive/$hash.tar.gz | shasum -a 256 | awk '{print $1}')
+
+sed -i.bak \
+    -e "s/CPP_JSONNET_SHA256 = .*/CPP_JSONNET_SHA256 = \"$sha256\"/;" \
+    -e "s/CPP_JSONNET_GITHASH = .*/CPP_JSONNET_GITHASH = \"$hash\"/;" \
+    bazel/repositories.bzl
+
+# NB: macOS sed doesn't support -i without arg. This is the easy workaround.
+rm bazel/repositories.bzl.bak
 
 set +x
 echo


### PR DESCRIPTION
Unlike naive `go build`, bazel builds generate `astgen/stdast.go` on the fly from cpp_jsonnet's stdlib.  Cool.

Previously however, the cpp_jsonnet versions in git submodule (used by naive `go build`) and bazel `http_archive` declarations were not in sync.  Not so cool.

This meant `bazel test //:go_default_test` failed on `TestEval/testdata/stdlib_smoke_test`, since the stale bazel cpp_jsonnet version lacked `std.get`.

This PR updates cpp-jsonnet to match git submodule version and teaches `update_cpp_jsonnet.sh` to update the cpp_jsonnet reference in `bazel/repositories.bzl` too.