### PR TITLE
Add a CI test that exercises bazel builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,20 @@ jobs:
           CGO_ENABLED: "1"
           SKIP_PYTHON_BINDINGS_TESTS: ${{ matrix.SKIP_PYTHON_BINDINGS_TESTS }}
 
+  bazel:
+    name: bazel test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/bazel
+            ~/.cache/bazelisk
+          key: ${{ runner.os }}-bazel-cache
+      - run: bazel build //...
+      - run: bazel test //...
+
   all:
     name: Check all
     runs-on: ubuntu-latest


### PR DESCRIPTION
If it's not tested, then it doesn't work.  Add a CI test that
executes `bazel build //...` and `bazel test //...`, in addition to
the non-bazel build system.