### PR TITLE
docs: add explicit mention for installing other tools in `cmd/`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ This code is known to work on Go 1.12 and above. We recommend always using the n
 # The version suffix is mandatory.
 go install github.com/google/go-jsonnet/cmd/jsonnet@latest
 
+# Or other tools in the 'cmd' directory
+go install github.com/google/go-jsonnet/cmd/jsonnet-lint@latest
+
 # go < 1.17
 go get github.com/google/go-jsonnet/cmd/jsonnet
 ```


### PR DESCRIPTION
This would close https://github.com/google/go-jsonnet/issues/634 and avoid similar issues in the future.

It makes it clear than you can also install other tools, not only `jsonnet`, from the `cmd/` directory. I used `jsonnet-lint` as an example.
