### PR TITLE
Adds jsonnet-lint to the releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,6 +42,26 @@ builds:
     main: ./cmd/jsonnetfmt
     binary: jsonnetfmt
 
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - 386
+      - amd64
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: 386
+
+    id: jsonnet-lint
+    main: ./cmd/jsonnet-lint
+    binary: jsonnet-lint
+
+
 archives:
   - replacements:
       darwin: Darwin
@@ -86,3 +106,19 @@ nfpms:
         conflicts:
           # See: https://packages.ubuntu.com/jsonnet
           - jsonnetfmt
+  - id: jsonnet-lint
+    package_name: jsonnet-lint-go
+    builds:
+      - jsonnet-lint
+    homepage: https://github.com/google/go-jsonnet
+    license: Apache 2.0
+    formats:
+      - deb
+    bindir: /usr/bin
+    maintainer: David Cunningham <dcunnin@google.com>
+    file_name_template: "jsonnet-lint-go_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    overrides:
+      deb:
+        conflicts:
+          # See: https://packages.ubuntu.com/jsonnet
+          - jsonnet-lint

--- a/cmd/jsonnet-lint/cmd.go
+++ b/cmd/jsonnet-lint/cmd.go
@@ -42,7 +42,7 @@ func usage(o io.Writer) {
 	fmt.Fprintln(o, "  Multichar options are expanded e.g. -abc becomes -a -b -c.")
 	fmt.Fprintln(o, "  The -- option suppresses option processing for subsequent arguments.")
 	fmt.Fprintln(o, "  Note that since filenames and jsonnet programs can begin with -, it is")
-	fmt.Fprintln(o, "  advised to use -- if the argument is unknown, e.g. jsonnetfmt -- \"$FILENAME\".")
+	fmt.Fprintln(o, "  advised to use -- if the argument is unknown, e.g. jsonnet-lint -- \"$FILENAME\".")
 	fmt.Fprintln(o)
 	fmt.Fprintln(o, "Exit code:")
 	fmt.Fprintln(o, "  0 – If the file was checked no problems were found.")


### PR DESCRIPTION
This PR should add jsonnet-lint to all the releases.

I haven't worked with a go releaser before. I think I figured out how the releases work for jsonnet and jsonnetfmt; I added similar stanzas for jsonnet-lint.