### PR TITLE
adding jsonnet-deps to release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,6 +61,25 @@ builds:
     main: ./cmd/jsonnet-lint
     binary: jsonnet-lint
 
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - 386
+      - amd64
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: 386
+
+    id: jsonnet-deps
+    main: ./cmd/jsonnet-deps
+    binary: jsonnet-deps
+
 
 archives:
   - replacements:
@@ -122,3 +141,19 @@ nfpms:
         conflicts:
           # See: https://packages.ubuntu.com/jsonnet
           - jsonnet-lint
+  - id: jsonnet-deps
+    package_name:  jsonnet-deps-go
+    builds:
+      - jsonnet-deps
+    homepage: https://github.com/google/go-jsonnet
+    license: Apache 2.0
+    formats:
+      - deb
+    bindir: /usr/bin
+    maintainer: David Cunningham <dcunnin@google.com>
+    file_name_template: " jsonnet-deps-go_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    overrides:
+      deb:
+        conflicts:
+          # See: https://packages.ubuntu.com/jsonnet
+          - jsonnet-deps


### PR DESCRIPTION
This should add `jsonnet-deps` to the release artifacts so that it is included in the release bundles in github:

https://github.com/google/go-jsonnet/releases

This is my first time using goreleaser so my apologies if I did something silly here.

