### PR TITLE
Add support for bzlmod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,20 @@
+module(name = "jsonnet_go", version = "0.0.0")
+
+bazel_dep(name = "gazelle", version = "0.30.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "jsonnet", version = "0.0.0", repo_name = "cpp_jsonnet")
+bazel_dep(name = "rules_go", version = "0.39.1", repo_name = "io_bazel_rules_go")
+
+git_override(
+    module_name = "jsonnet",
+    remote = "https://github.com/mortenmj/jsonnet.git",
+    commit = "df811822d9a31cb3fab9bdf68679ad300f1c12ed",
+)
+
+go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "@jsonnet_go//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_fatih_color",
+    "com_github_sergi_go_diff",
+    "io_k8s_sigs_yaml",
+)


### PR DESCRIPTION
This PR adds a MODULE.bazel file which allows other repositories to import this one as a bzlmod module.
I don't know how Google handles publishing to the Bazel Central Registry, so I haven't made any attempt at that.

This is ready for review, but not for merging, pending https://github.com/google/jsonnet/pull/1083 which adds bzlmod support for jsonnet. Jsonnet would need to be added to the Bazel Central Registry for this PR to be merged, as bzlmod does not allow importing modules that use overrides (such as `git_override` used here).
