### PR TITLE
Teach jsonnet-lint about optional parameters of std.manifestYamlDoc

### DIFF
--- a/linter/internal/types/stdlib.go
+++ b/linter/internal/types/stdlib.go
@@ -115,7 +115,7 @@ func prepareStdlib(g *typeGraph) {
 		"manifestTomlEx":       g.newSimpleFuncType(stringType, "value", "indent"),
 		"manifestJsonEx":       g.newSimpleFuncType(stringType, "value", "indent"),
 		"manifestJsonMinified": g.newSimpleFuncType(stringType, "value"),
-		"manifestYamlDoc":      g.newSimpleFuncType(stringType, "value"),
+		"manifestYamlDoc":      g.newFuncType(stringType, []ast.Parameter{required("value"), optional("indent_array_in_object"), optional("quote_keys")}),
 		"manifestYamlStream":   g.newSimpleFuncType(stringType, "value"),
 		"manifestXmlJsonml":    g.newSimpleFuncType(stringType, "value"),
 

--- a/linter/testdata/stdlib_manifestYamlDoc.jsonnet
+++ b/linter/testdata/stdlib_manifestYamlDoc.jsonnet
@@ -1,0 +1,3 @@
+std.manifestYamlDoc({
+  hello: 'world',
+}, indent_array_in_object=false, quote_keys=true)


### PR DESCRIPTION
manifestYamlDoc takes two optional parameters, `indent_array_in_object` and `quote_keys`. This commit teaches jsonnet-lint about them so that it doesn't raise errors when you use them.

There are other stdlib library functions with this problem; the true solution is probably to auto-generate this from the stdlib AST, but this at least gets the linter happy with this particular function.