### PR TITLE
Expose "unparse", FormatNode and RawAST

### DIFF
--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -4,7 +4,10 @@
 // customized using formatter.Options.
 package formatter
 
-import "github.com/google/go-jsonnet/internal/formatter"
+import (
+	"github.com/google/go-jsonnet/ast"
+	"github.com/google/go-jsonnet/internal/formatter"
+)
 
 // StringStyle controls how the reformatter rewrites string literals.
 // Strings that contain a ' or a " use the optimal syntax to avoid escaping
@@ -45,4 +48,10 @@ func DefaultOptions() Options {
 // according to the given options.
 func Format(filename string, input string, options Options) (string, error) {
 	return formatter.Format(filename, input, options)
+}
+
+// FormatNode returns code that is equivalent to its input but better formatted
+// according to the given options.
+func FormatNode(node ast.Node, finalFodder ast.Fodder, options Options) (string, error) {
+	return formatter.FormatNode(node, finalFodder, options)
 }

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -7,6 +7,7 @@ package formatter
 import (
 	"github.com/google/go-jsonnet/ast"
 	"github.com/google/go-jsonnet/internal/formatter"
+	"github.com/google/go-jsonnet/internal/parser"
 )
 
 // StringStyle controls how the reformatter rewrites string literals.
@@ -54,4 +55,9 @@ func Format(filename string, input string, options Options) (string, error) {
 // according to the given options.
 func FormatNode(node ast.Node, finalFodder ast.Fodder, options Options) (string, error) {
 	return formatter.FormatNode(node, finalFodder, options)
+}
+
+// SnippetToRawAST parses a snippet and returns the resulting AST.
+func SnippetToRawAST(filename string, snippet string) (ast.Node, ast.Fodder, error) {
+	return parser.SnippetToRawAST(ast.DiagnosticFileName(filename), "", snippet)
 }

--- a/internal/formatter/jsonnetfmt.go
+++ b/internal/formatter/jsonnetfmt.go
@@ -152,6 +152,10 @@ func Format(filename string, input string, options Options) (string, error) {
 		return "", err
 	}
 
+	return FormatNode(node, finalFodder, options)
+}
+
+func FormatNode(node ast.Node, finalFodder ast.Fodder, options Options) (string, error) {
 	// Passes to enforce style on the AST.
 	if options.SortImports {
 		SortImports(&node)

--- a/internal/formatter/jsonnetfmt.go
+++ b/internal/formatter/jsonnetfmt.go
@@ -155,6 +155,8 @@ func Format(filename string, input string, options Options) (string, error) {
 	return FormatNode(node, finalFodder, options)
 }
 
+// FormatNode returns code that is equivalent to its input but better formatted
+// according to the given options.
 func FormatNode(node ast.Node, finalFodder ast.Fodder, options Options) (string, error) {
 	// Passes to enforce style on the AST.
 	if options.SortImports {


### PR DESCRIPTION
This is a rebased version of #530 by @tomwilkie:

> (Opening this for discussion, see https://github.com/google/go-jsonnet/issues/389)
> 
> I've build a little tool that does some modifications to jsonnet files (updating docker image versions in them), and wanted to use the pretty-printing code to write out the modified AST.
> 
> This is a minimal set of changes that allow me to do that.