### PR TITLE
Add canonicalize ast pass to jsonnetfmt.

### DIFF
--- a/cmd/jsonnetfmt/cmd.go
+++ b/cmd/jsonnetfmt/cmd.go
@@ -60,6 +60,7 @@ func usage(o io.Writer) {
 	fmt.Fprintln(o, "  --[no-]sort-imports        Sorting of imports (on by default)")
 	fmt.Fprintln(o, "  --[no-]use-implicit-plus   Remove plus signs where they are not required")
 	fmt.Fprintln(o, "                             (on by default)")
+	fmt.Fprintln(o, "  --canonicalize             Generate a canonical output")
 	fmt.Fprintln(o, "  --version                  Print version")
 	fmt.Fprintln(o)
 	fmt.Fprintln(o, "In all cases:")
@@ -181,6 +182,8 @@ func processArgs(givenArgs []string, config *config, vm *jsonnet.VM) (processArg
 			config.options.PadObjects = false
 		} else if arg == "--sort-imports" {
 			config.options.SortImports = true
+		} else if arg == "--canonicalize" {
+			config.options.Canonicalize = true
 		} else if arg == "--no-sort-imports" {
 			config.options.SortImports = false
 		} else if arg == "-c" || arg == "--create-output-dirs" {

--- a/internal/formatter/canonicalize.go
+++ b/internal/formatter/canonicalize.go
@@ -1,0 +1,117 @@
+package formatter
+
+import (
+	"github.com/google/go-jsonnet/ast"
+	"github.com/google/go-jsonnet/internal/pass"
+	"sort"
+)
+
+// Canonicalize is a formatter that will update objects and arrays
+// to their canonical form, i.e. sorting object fields and array elements.
+type Canonicalize struct {
+	pass.Base
+}
+
+type SortableField struct {
+	Kind  int
+	Key   string
+	Field ast.ObjectField
+}
+
+func (c *Canonicalize) sortFields(fields ast.ObjectFields) {
+
+	var sortableFields = make([]SortableField, len(fields))
+
+	// We first construct a sortable representation of the fields using
+	// the kind as precedence indicator:
+	//   - asserts
+	//   - locals
+	//   - any object field
+	for index, field := range fields {
+		var kind = 0
+
+		switch field.Kind {
+		case ast.ObjectAssert:
+			kind = 0
+		case ast.ObjectFieldID:
+			kind = 2
+		case ast.ObjectFieldExpr:
+			kind = 2
+		case ast.ObjectFieldStr:
+			kind = 2
+		case ast.ObjectLocal:
+			kind = 1
+		}
+
+		// generate a string representation of each field
+		u := &unparser{options: Options{StripEverything: true}}
+		var singleField = make([]ast.ObjectField, 1)
+		singleField[0] = field
+		u.unparseFields(singleField, false)
+
+		sortableFields[index] = SortableField{Kind: kind, Key: u.string(), Field: field}
+	}
+
+	// sort the fields using a stable sort to ensure that order
+	// of some fields (local and assert expressions) is retained as
+	// contained in the original ast.
+	sort.SliceStable(sortableFields, func(i, j int) bool {
+		if sortableFields[i].Kind != sortableFields[j].Kind {
+			return sortableFields[i].Kind < sortableFields[j].Kind
+		}
+
+		// retain original order local and assert expressions,
+		if sortableFields[i].Kind < 2 {
+			return false
+		} else {
+			return sortableFields[i].Key < sortableFields[j].Key
+		}
+	})
+
+	for index, field := range sortableFields {
+		fields[index] = field.Field
+	}
+}
+
+type SortableElement struct {
+	Key     string
+	Element ast.CommaSeparatedExpr
+}
+
+func (c *Canonicalize) sortArrayElements(elements []ast.CommaSeparatedExpr) {
+	var sortableElements = make([]SortableElement, len(elements))
+
+	for index, element := range elements {
+		u := &unparser{options: Options{StripEverything: true}}
+		u.unparse(element.Expr, false)
+		sortableElements[index] = SortableElement{Key: u.string(), Element: element}
+	}
+
+	sort.SliceStable(sortableElements, func(i, j int) bool {
+		return sortableElements[i].Key < sortableElements[j].Key
+	})
+
+	for index, element := range sortableElements {
+		elements[index] = element.Element
+	}
+}
+
+// Array handles that type of node
+func (c *Canonicalize) Array(p pass.ASTPass, node *ast.Array, ctx pass.Context) {
+	if len(node.Elements) == 0 {
+		// No comma present and none can be added.
+		return
+	}
+	c.sortArrayElements(node.Elements)
+	c.Base.Array(p, node, ctx)
+}
+
+// Object handles that type of node
+func (c *Canonicalize) Object(p pass.ASTPass, node *ast.Object, ctx pass.Context) {
+	if len(node.Fields) == 0 {
+		// No fields present.
+		return
+	}
+	c.sortFields(node.Fields)
+	c.Base.Object(p, node, ctx)
+}

--- a/internal/formatter/jsonnetfmt.go
+++ b/internal/formatter/jsonnetfmt.go
@@ -74,6 +74,8 @@ type Options struct {
 	StripEverything     bool
 	StripComments       bool
 	StripAllButComments bool
+
+	Canonicalize bool
 }
 
 // DefaultOptions returns the recommended formatter behaviour.
@@ -88,6 +90,7 @@ func DefaultOptions() Options {
 		PadArrays:        false,
 		PadObjects:       true,
 		SortImports:      true,
+		Canonicalize:     false,
 	}
 }
 
@@ -195,6 +198,10 @@ func FormatNode(node ast.Node, finalFodder ast.Fodder, options Options) (string,
 		visitor := FixIndentation{Options: options}
 		visitor.VisitFile(node, finalFodder)
 	}
+	if options.Canonicalize {
+		visitFile(&Canonicalize{}, &node, &finalFodder)
+	}
+
 	removeExtraTrailingNewlines(finalFodder)
 
 	u := &unparser{options: options}

--- a/internal/formatter/unparser.go
+++ b/internal/formatter/unparser.go
@@ -51,6 +51,9 @@ func (u *unparser) write(str string) {
 // If crowded is false and separateToken is false then no space is printed
 // after or before the fodder, even if the last fodder was an interstitial.
 func (u *unparser) fodderFill(fodder ast.Fodder, crowded bool, separateToken bool, final bool) {
+	if u.options.StripEverything {
+		return
+	}
 	var lastIndent int
 	for i, fod := range fodder {
 		skipTrailing := final && (i == (len(fodder) - 1))


### PR DESCRIPTION
This PR is a POC implementation for #721 .

It is intended to get feedback if something like this makes sense and if the implementation of that is reasonable.

The PR only considers objects and arrays and will sort them using the following criteria.

objects:

-  locals and asserts are untouched and should be above all other object fields
- object fields are converted to string representation using unparser
- comments and whitespace are stripped when converting to string representation

arrays:

- elements are converted to string representation using unparser