### PR TITLE
Fix linter: using a local in an assertion.

### DIFF
--- a/linter/internal/variables/find_variables.go
+++ b/linter/internal/variables/find_variables.go
@@ -67,6 +67,9 @@ func findVariablesInObject(node *ast.DesugaredObject, info *common.VariableInfo,
 	for _, local := range node.Locals {
 		findVariables(local.Body, info, scopeInside)
 	}
+	for _, assert := range node.Asserts {
+		findVariables(assert, info, scopeInside)
+	}
 	for _, field := range node.Fields {
 		findVariables(field.Body, info, scopeInside)
 		findVariables(field.Name, info, scopeOutside)

--- a/linter/testdata/local_used_in_assertion.jsonnet
+++ b/linter/testdata/local_used_in_assertion.jsonnet
@@ -1,0 +1,6 @@
+{
+    local input = [1,2,3],
+    local knownItems = [1,2],
+    local unknownItems = std.filter(function(i) !(i in knownItems), input),
+    assert unknownItems == [] : "unexpected items: %s" % std.join(",",unknownItems)
+}

--- a/testdata/local_in_object_assertion.linter.golden
+++ b/testdata/local_in_object_assertion.linter.golden
@@ -1,5 +1,0 @@
-../testdata/local_in_object_assertion:1:9-15 Unused variable: x
-
-{ local x = 42, assert x == 42 }
-
-


### PR DESCRIPTION
This fixes #617.

While working on the fix an existing test was discovered that outlines the same bug. It could be fixed after fixing the bug itself.