### PR TITLE
chore: fix CI to follow the deprecation of goreleaser flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,4 +97,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goreleaser/goreleaser-action@v2
         with:
-          args: release --snapshot --skip-publish --rm-dist
+          args: release --snapshot --skip=publish --clean

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
-# This is an example goreleaser.yaml file with some sane defaults.
-# Make sure to check the documentation at http://goreleaser.com
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+
+version: 2
 
 builds:
   - env:
@@ -9,13 +10,13 @@ builds:
       - windows
       - darwin
     goarch:
-      - 386
+      - "386"
       - amd64
       - arm
       - arm64
     ignore:
       - goos: darwin
-        goarch: 386
+        goarch: "386"
 
     id: jsonnet
     main: ./cmd/jsonnet
@@ -30,13 +31,13 @@ builds:
       - windows
       - darwin
     goarch:
-      - 386
+      - "386"
       - amd64
       - arm
       - arm64
     ignore:
       - goos: darwin
-        goarch: 386
+        goarch: "386"
 
     id: jsonnetfmt
     main: ./cmd/jsonnetfmt
@@ -49,13 +50,13 @@ builds:
       - windows
       - darwin
     goarch:
-      - 386
+      - "386"
       - amd64
       - arm
       - arm64
     ignore:
       - goos: darwin
-        goarch: 386
+        goarch: "386"
 
     id: jsonnet-lint
     main: ./cmd/jsonnet-lint
@@ -68,13 +69,13 @@ builds:
       - windows
       - darwin
     goarch:
-      - 386
+      - "386"
       - amd64
       - arm
       - arm64
     ignore:
       - goos: darwin
-        goarch: 386
+        goarch: "386"
 
     id: jsonnet-deps
     main: ./cmd/jsonnet-deps
@@ -82,12 +83,14 @@ builds:
 
 
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{- .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end -}}
+
 checksum:
   name_template: "checksums.txt"
 


### PR DESCRIPTION
See <https://github.com/goreleaser/goreleaser/blob/v2.0.0/www/docs/deprecations.md> for details.
