### PR TITLE
Add digit separators to Jsonnet

### DIFF
--- a/internal/parser/lexer.go
+++ b/internal/parser/lexer.go
@@ -557,7 +557,7 @@ outerLoop:
 					l.location())
 
 			case r >= '0' && r <= '9':
-				state = numAfterExpDigit
+				state = numAfterOneToNine
 
 			default:
 				return l.makeStaticErrorPoint(
@@ -589,11 +589,29 @@ outerLoop:
 			case r >= '0' && r <= '9':
 				state = numAfterExpDigit
 			case r == '_':
-				state = numAfterUnderscore
+				state = numAfterExpUnderscore
 			default:
 				break outerLoop
 			}
+
+		case numAfterExpUnderscore:
+			// The only valid transition out of _ is to a digit.
+			switch {
+			case r == '_':
+				return l.makeStaticErrorPoint(
+					"Couldn't lex number, multiple consecutive _'s",
+					l.location())
+
+			case r >= '0' && r <= '9':
+				state = numAfterExpDigit
+
+			default:
+				return l.makeStaticErrorPoint(
+					fmt.Sprintf("Couldn't lex number, junk after '_': %v", strconv.QuoteRuneToASCII(r)),
+					l.location())
+			}
 		}
+
 		l.next()
 	}
 

--- a/internal/parser/lexer_test.go
+++ b/internal/parser/lexer_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package parser
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-jsonnet/ast"
@@ -315,23 +316,81 @@ func TestNumber1epExc(t *testing.T) {
 }
 
 func TestNumberSeparators(t *testing.T) {
+	cases := [...]struct {
+		input  string
+		err    string
+		tokens Tokens
+	}{
+		{
+			input:  "123_456",
+			err:    "",
+			tokens: Tokens{{kind: tokenNumber, data: "123456"}},
+		},
+		{
+			input:  "1_750_000",
+			err:    "",
+			tokens: Tokens{{kind: tokenNumber, data: "1750000"}},
+		},
+		{
+			input:  "1_2_3",
+			err:    "",
+			tokens: Tokens{{kind: tokenNumber, data: "123"}},
+		},
+		{
+			input:  "3.141_592",
+			err:    "",
+			tokens: Tokens{{kind: tokenNumber, data: "3.141592"}},
+		},
+		{
+			input: "01_100",
+			err:   "",
+			tokens: Tokens{
+				{kind: tokenNumber, data: "0"},
+				{kind: tokenNumber, data: "1100"},
+			},
+		},
+		{
+			input:  "1_200.0",
+			err:    "",
+			tokens: Tokens{{kind: tokenNumber, data: "1200.0"}},
+		},
+		{
+			input:  "0e1_01",
+			err:    "",
+			tokens: Tokens{{kind: tokenNumber, data: "0e101"}},
+		},
+		{
+			input:  "10_10e3",
+			err:    "",
+			tokens: Tokens{{kind: tokenNumber, data: "1010e3"}},
+		},
+		{
+			input:  "2_3e1_2",
+			err:    "",
+			tokens: Tokens{{kind: tokenNumber, data: "23e12"}},
+		},
+		{
+			input:  "1.1_2e100",
+			err:    "",
+			tokens: Tokens{{kind: tokenNumber, data: "1.12e100"}},
+		},
+		{
+			input:  "1.1e-10_1",
+			err:    "",
+			tokens: Tokens{{kind: tokenNumber, data: "1.1e-101"}},
+		},
+		{
+			input:  "9.109_383_56e-31",
+			err:    "",
+			tokens: Tokens{{kind: tokenNumber, data: "9.10938356e-31"}},
+		},
+	}
 
-	SingleTest(t, "123_456", "", Tokens{{kind: tokenNumber, data: "123456"}})
-
-	/*
-			testLex("number 123_456", "123_456", {Token(Token::Kind::NUMBER, "123456")}, "");
-		    testLex("number 1_750_000", "1_750_000", {Token(Token::Kind::NUMBER, "1750000")}, "");
-		    testLex("number 1_2_3", "1_2_3", {Token(Token::Kind::NUMBER, "123")}, "");
-		    testLex("number 3.141_592", "3.141_592", {Token(Token::Kind::NUMBER, "3.141592")}, "");
-		    testLex("number 01_100", "01_100", {Token(Token::Kind::NUMBER, "0"), Token(Token::Kind::NUMBER, "1100")}, "");
-		    testLex("number 1_200.0", "1_200.0", {Token(Token::Kind::NUMBER, "1200.0")}, "");
-		    testLex("number 0e1_01", "0e1_01", {Token(Token::Kind::NUMBER, "0e101")}, "");
-		    testLex("number 10_10e3", "10_10e3", {Token(Token::Kind::NUMBER, "1010e3")}, "");
-		    testLex("number 2_3e1_2", "2_3e1_2", {Token(Token::Kind::NUMBER, "23e12")}, "");
-		    testLex("number 1.1_2e100", "1.1_2e100", {Token(Token::Kind::NUMBER, "1.12e100")}, "");
-		    testLex("number 1.1e-10_1", "1.1e-10_1", {Token(Token::Kind::NUMBER, "1.1e-101")}, "");
-		    testLex("number 9.109_383_56e-31", "9.109_383_56e-31", {Token(Token::Kind::NUMBER, "9.10938356e-31")}, "");
-	*/
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("number %s", c.input), func(t *testing.T) {
+			SingleTest(t, c.input, c.err, c.tokens)
+		})
+	}
 }
 
 func TestDoublestring1(t *testing.T) {

--- a/internal/parser/lexer_test.go
+++ b/internal/parser/lexer_test.go
@@ -316,38 +316,31 @@ func TestNumber1epExc(t *testing.T) {
 }
 
 func TestNumberSeparators(t *testing.T) {
-	type numcase struct {
+	for _, c := range []struct {
 		input  string
 		err    string
 		tokens Tokens
-	}
-	mknumcase := func(input string, err string, tokens Tokens) numcase {
-		return numcase{input, err, tokens}
-	}
-	for _, c := range [...]numcase{
-		mknumcase("123_456", "", Tokens{{kind: tokenNumber, data: "123456"}}),
-		mknumcase("1_750_000", "", Tokens{{kind: tokenNumber, data: "1750000"}}),
-		mknumcase("1_2_3", "", Tokens{{kind: tokenNumber, data: "123"}}),
-		mknumcase("3.141_592", "", Tokens{{kind: tokenNumber, data: "3.141592"}}),
-		mknumcase("01_100", "", Tokens{
-			{kind: tokenNumber, data: "0"},
-			{kind: tokenNumber, data: "1100"},
-		}),
-		mknumcase("1_200.0", "", Tokens{{kind: tokenNumber, data: "1200.0"}}),
-		mknumcase("0e1_01", "", Tokens{{kind: tokenNumber, data: "0e101"}}),
-		mknumcase("10_10e3", "", Tokens{{kind: tokenNumber, data: "1010e3"}}),
-		mknumcase("2_3e1_2", "", Tokens{{kind: tokenNumber, data: "23e12"}}),
-		mknumcase("1.1_2e100", "", Tokens{{kind: tokenNumber, data: "1.12e100"}}),
-		mknumcase("1.1e-10_1", "", Tokens{{kind: tokenNumber, data: "1.1e-101"}}),
-		mknumcase("9.109_383_56e-31", "", Tokens{{kind: tokenNumber, data: "9.10938356e-31"}}),
-		mknumcase("123456_!", "snippet:1:8 Couldn't lex number, junk after '_': '!'", Tokens{}),
-		mknumcase("123__456", "snippet:1:5 Couldn't lex number, multiple consecutive _'s", Tokens{}),
-		mknumcase("1_200_.0", "snippet:1:7 Couldn't lex number, junk after '_': '.'", Tokens{}),
-		mknumcase("1_200._0", "snippet:1:7 Couldn't lex number, junk after decimal point: '_'", Tokens{}),
-		mknumcase("1_200_e2", "snippet:1:7 Couldn't lex number, junk after '_': 'e'", Tokens{}),
-		mknumcase("1_200e_2", "snippet:1:7 Couldn't lex number, junk after 'E': '_'", Tokens{}),
-		mknumcase("200e-_2", "snippet:1:6 Couldn't lex number, junk after exponent sign: '_'", Tokens{}),
-		mknumcase("200e+_2", "snippet:1:6 Couldn't lex number, junk after exponent sign: '_'", Tokens{}),
+	}{
+		{"123_456", "", Tokens{{kind: tokenNumber, data: "123456"}}},
+		{"1_750_000", "", Tokens{{kind: tokenNumber, data: "1750000"}}},
+		{"1_2_3", "", Tokens{{kind: tokenNumber, data: "123"}}},
+		{"3.141_592", "", Tokens{{kind: tokenNumber, data: "3.141592"}}},
+		{"01_100", "", Tokens{{kind: tokenNumber, data: "0"}, {kind: tokenNumber, data: "1100"}}},
+		{"1_200.0", "", Tokens{{kind: tokenNumber, data: "1200.0"}}},
+		{"0e1_01", "", Tokens{{kind: tokenNumber, data: "0e101"}}},
+		{"10_10e3", "", Tokens{{kind: tokenNumber, data: "1010e3"}}},
+		{"2_3e1_2", "", Tokens{{kind: tokenNumber, data: "23e12"}}},
+		{"1.1_2e100", "", Tokens{{kind: tokenNumber, data: "1.12e100"}}},
+		{"1.1e-10_1", "", Tokens{{kind: tokenNumber, data: "1.1e-101"}}},
+		{"9.109_383_56e-31", "", Tokens{{kind: tokenNumber, data: "9.10938356e-31"}}},
+		{"123456_!", "snippet:1:8 Couldn't lex number, junk after '_': '!'", Tokens{}},
+		{"123__456", "snippet:1:5 Couldn't lex number, multiple consecutive _'s", Tokens{}},
+		{"1_200_.0", "snippet:1:7 Couldn't lex number, junk after '_': '.'", Tokens{}},
+		{"1_200._0", "snippet:1:7 Couldn't lex number, junk after decimal point: '_'", Tokens{}},
+		{"1_200_e2", "snippet:1:7 Couldn't lex number, junk after '_': 'e'", Tokens{}},
+		{"1_200e_2", "snippet:1:7 Couldn't lex number, junk after 'E': '_'", Tokens{}},
+		{"200e-_2", "snippet:1:6 Couldn't lex number, junk after exponent sign: '_'", Tokens{}},
+		{"200e+_2", "snippet:1:6 Couldn't lex number, junk after exponent sign: '_'", Tokens{}},
 	} {
 		t.Run(fmt.Sprintf("number %s", c.input), func(t *testing.T) {
 			SingleTest(t, c.input, c.err, c.tokens)

--- a/internal/parser/lexer_test.go
+++ b/internal/parser/lexer_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -312,6 +312,26 @@ func TestNumber1eExc(t *testing.T) {
 
 func TestNumber1epExc(t *testing.T) {
 	SingleTest(t, "1e+!", "snippet:1:4 Couldn't lex number, junk after exponent sign: '!'", Tokens{})
+}
+
+func TestNumberSeparators(t *testing.T) {
+
+	SingleTest(t, "123_456", "", Tokens{{kind: tokenNumber, data: "123456"}})
+
+	/*
+			testLex("number 123_456", "123_456", {Token(Token::Kind::NUMBER, "123456")}, "");
+		    testLex("number 1_750_000", "1_750_000", {Token(Token::Kind::NUMBER, "1750000")}, "");
+		    testLex("number 1_2_3", "1_2_3", {Token(Token::Kind::NUMBER, "123")}, "");
+		    testLex("number 3.141_592", "3.141_592", {Token(Token::Kind::NUMBER, "3.141592")}, "");
+		    testLex("number 01_100", "01_100", {Token(Token::Kind::NUMBER, "0"), Token(Token::Kind::NUMBER, "1100")}, "");
+		    testLex("number 1_200.0", "1_200.0", {Token(Token::Kind::NUMBER, "1200.0")}, "");
+		    testLex("number 0e1_01", "0e1_01", {Token(Token::Kind::NUMBER, "0e101")}, "");
+		    testLex("number 10_10e3", "10_10e3", {Token(Token::Kind::NUMBER, "1010e3")}, "");
+		    testLex("number 2_3e1_2", "2_3e1_2", {Token(Token::Kind::NUMBER, "23e12")}, "");
+		    testLex("number 1.1_2e100", "1.1_2e100", {Token(Token::Kind::NUMBER, "1.12e100")}, "");
+		    testLex("number 1.1e-10_1", "1.1e-10_1", {Token(Token::Kind::NUMBER, "1.1e-101")}, "");
+		    testLex("number 9.109_383_56e-31", "9.109_383_56e-31", {Token(Token::Kind::NUMBER, "9.10938356e-31")}, "");
+	*/
 }
 
 func TestDoublestring1(t *testing.T) {

--- a/internal/parser/lexer_test.go
+++ b/internal/parser/lexer_test.go
@@ -316,77 +316,39 @@ func TestNumber1epExc(t *testing.T) {
 }
 
 func TestNumberSeparators(t *testing.T) {
-	cases := [...]struct {
+	type numcase struct {
 		input  string
 		err    string
 		tokens Tokens
-	}{
-		{
-			input:  "123_456",
-			err:    "",
-			tokens: Tokens{{kind: tokenNumber, data: "123456"}},
-		},
-		{
-			input:  "1_750_000",
-			err:    "",
-			tokens: Tokens{{kind: tokenNumber, data: "1750000"}},
-		},
-		{
-			input:  "1_2_3",
-			err:    "",
-			tokens: Tokens{{kind: tokenNumber, data: "123"}},
-		},
-		{
-			input:  "3.141_592",
-			err:    "",
-			tokens: Tokens{{kind: tokenNumber, data: "3.141592"}},
-		},
-		{
-			input: "01_100",
-			err:   "",
-			tokens: Tokens{
-				{kind: tokenNumber, data: "0"},
-				{kind: tokenNumber, data: "1100"},
-			},
-		},
-		{
-			input:  "1_200.0",
-			err:    "",
-			tokens: Tokens{{kind: tokenNumber, data: "1200.0"}},
-		},
-		{
-			input:  "0e1_01",
-			err:    "",
-			tokens: Tokens{{kind: tokenNumber, data: "0e101"}},
-		},
-		{
-			input:  "10_10e3",
-			err:    "",
-			tokens: Tokens{{kind: tokenNumber, data: "1010e3"}},
-		},
-		{
-			input:  "2_3e1_2",
-			err:    "",
-			tokens: Tokens{{kind: tokenNumber, data: "23e12"}},
-		},
-		{
-			input:  "1.1_2e100",
-			err:    "",
-			tokens: Tokens{{kind: tokenNumber, data: "1.12e100"}},
-		},
-		{
-			input:  "1.1e-10_1",
-			err:    "",
-			tokens: Tokens{{kind: tokenNumber, data: "1.1e-101"}},
-		},
-		{
-			input:  "9.109_383_56e-31",
-			err:    "",
-			tokens: Tokens{{kind: tokenNumber, data: "9.10938356e-31"}},
-		},
 	}
-
-	for _, c := range cases {
+	mknumcase := func(input string, err string, tokens Tokens) numcase {
+		return numcase{input, err, tokens}
+	}
+	for _, c := range [...]numcase{
+		mknumcase("123_456", "", Tokens{{kind: tokenNumber, data: "123456"}}),
+		mknumcase("1_750_000", "", Tokens{{kind: tokenNumber, data: "1750000"}}),
+		mknumcase("1_2_3", "", Tokens{{kind: tokenNumber, data: "123"}}),
+		mknumcase("3.141_592", "", Tokens{{kind: tokenNumber, data: "3.141592"}}),
+		mknumcase("01_100", "", Tokens{
+			{kind: tokenNumber, data: "0"},
+			{kind: tokenNumber, data: "1100"},
+		}),
+		mknumcase("1_200.0", "", Tokens{{kind: tokenNumber, data: "1200.0"}}),
+		mknumcase("0e1_01", "", Tokens{{kind: tokenNumber, data: "0e101"}}),
+		mknumcase("10_10e3", "", Tokens{{kind: tokenNumber, data: "1010e3"}}),
+		mknumcase("2_3e1_2", "", Tokens{{kind: tokenNumber, data: "23e12"}}),
+		mknumcase("1.1_2e100", "", Tokens{{kind: tokenNumber, data: "1.12e100"}}),
+		mknumcase("1.1e-10_1", "", Tokens{{kind: tokenNumber, data: "1.1e-101"}}),
+		mknumcase("9.109_383_56e-31", "", Tokens{{kind: tokenNumber, data: "9.10938356e-31"}}),
+		mknumcase("123456_!", "snippet:1:8 Couldn't lex number, junk after '_': '!'", Tokens{}),
+		mknumcase("123__456", "snippet:1:5 Couldn't lex number, multiple consecutive _'s", Tokens{}),
+		mknumcase("1_200_.0", "snippet:1:7 Couldn't lex number, junk after '_': '.'", Tokens{}),
+		mknumcase("1_200._0", "snippet:1:7 Couldn't lex number, junk after decimal point: '_'", Tokens{}),
+		mknumcase("1_200_e2", "snippet:1:7 Couldn't lex number, junk after '_': 'e'", Tokens{}),
+		mknumcase("1_200e_2", "snippet:1:7 Couldn't lex number, junk after 'E': '_'", Tokens{}),
+		mknumcase("200e-_2", "snippet:1:6 Couldn't lex number, junk after exponent sign: '_'", Tokens{}),
+		mknumcase("200e+_2", "snippet:1:6 Couldn't lex number, junk after exponent sign: '_'", Tokens{}),
+	} {
 		t.Run(fmt.Sprintf("number %s", c.input), func(t *testing.T) {
 			SingleTest(t, c.input, c.err, c.tokens)
 		})

--- a/internal/parser/lexer_test.go
+++ b/internal/parser/lexer_test.go
@@ -525,6 +525,12 @@ func TestIdentifiers(t *testing.T) {
 	})
 }
 
+func TestIdentifierUnderscore(t *testing.T) {
+	SingleTest(t, "_123", "", Tokens{
+		{kind: tokenIdentifier, data: "_123"},
+	})
+}
+
 func TestCppComment(t *testing.T) {
 	SingleTest(t, "// hi", "", Tokens{
 		{kind: tokenEndOfFile, fodder: ast.Fodder{{Kind: ast.FodderParagraph, Comment: []string{"// hi"}}}},


### PR DESCRIPTION
This is a draft implementation of adding digit separators (`1_000`) to Jsonnet's numeric constants.

Companion to the same draft PR in C++ repo: https://github.com/google/jsonnet/pull/1160
Reference issue: https://github.com/google/jsonnet/issues/1155