### PR TITLE
Fix compatibility with setuptools 72

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ import os
 from setuptools import setup
 from setuptools import Extension
 from setuptools.command.build_ext import build_ext as BuildExt
-from setuptools.command.test import test as TestCommand
 from subprocess import Popen, PIPE
 
 DIR = os.path.abspath(os.path.dirname(__file__))
@@ -52,14 +51,6 @@ class BuildJsonnetExt(BuildExt):
 
         BuildExt.run(self)
 
-
-class NoopTestCommand(TestCommand):
-    def __init__(self, dist):
-        print(
-            "_gojsonnet does not support running tests with 'python setup.py test'. Please run 'pytest'."
-        )
-
-
 jsonnet_ext = Extension(
     "_gojsonnet",
     sources=MODULE_SOURCES,
@@ -79,7 +70,6 @@ setup(
     version=get_version(),
     cmdclass={
         "build_ext": BuildJsonnetExt,
-        "test": NoopTestCommand,
     },
     ext_modules=[jsonnet_ext],
 )


### PR DESCRIPTION
Due to [test command removal](https://github.com/pypa/setuptools/issues/4519) in setuptools, installation fails with version 72:

```
# pip wheel --no-cache-dir --use-pep517 "gojsonnet (==0.20.0)"
Collecting gojsonnet==0.20.0
  Downloading gojsonnet-0.20.0.tar.gz (7.4 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 7.4/7.4 MB 15.0 MB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [17 lines of output]
      Traceback (most recent call last):
        File "/usr/local/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/usr/local/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/usr/local/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-i9xslfbh/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 327, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
        File "/tmp/pip-build-env-i9xslfbh/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 297, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-i9xslfbh/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 497, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-i9xslfbh/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 313, in run_setup
          exec(code, locals())
        File "<string>", line 19, in <module>
      ModuleNotFoundError: No module named 'setuptools.command.test'
```

pytest [advises](https://github.com/pytest-dev/pytest/pull/5546) to not integrate with setuptools anymore, thus I've dropped that part.