### PR TITLE
Add SetVM and GetVM methods to Debugger for TLA and extCode integration

### DIFF
--- a/debugger.go
+++ b/debugger.go
@@ -345,6 +345,16 @@ func (d *Debugger) StackTrace() []TraceFrame {
 	return trace
 }
 
+func (d *Debugger) SetVM(vm *VM) {
+	if vm != nil {
+		d.vm = vm
+	}
+}
+
+func (d *Debugger) GetVM() *VM {
+	return d.vm
+}
+
 func debugValueToString(v value) string {
 	switch i := v.(type) {
 	case *valueFlatString:


### PR DESCRIPTION
This PR introduces two new methods, `SetVM` and `GetVM`, to the `Debugger` struct in `debugger.go`. These methods provide access to the underlying `VM` instance associated with the debugger:

* **`SetVM(vm *VM)`:** Sets the `VM` instance to be used by the debugger. This allows for dynamic configuration or replacement of the VM during the debugging process, enabling the integration of TLA and ext functionality.
* **`GetVM() *VM`:** Returns the current `VM` instance being used by the debugger. This can be useful for inspecting or modifying the VM's state.

The addition of these methods enhances the flexibility and control of the go-jsonnet debugger, making it easier to integrate TLA and ext features.
