### PR TITLE
Update CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - master
       - prepare-release
+
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test go${{ matrix.goVersion}}.x ${{ matrix.goArch }}
@@ -38,8 +42,8 @@ jobs:
             SKIP_PYTHON_BINDINGS_TESTS: "0"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.goVersion }}
       - run: sudo apt install python3-dev python3-setuptools
@@ -56,8 +60,8 @@ jobs:
     name: bazel test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/bazel
@@ -70,7 +74,7 @@ jobs:
     name: Check all
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: sudo apt install python3-dev python3-setuptools
       - run: pip install -U wheel
       - run: pip install -U pytest setuptools
@@ -92,7 +96,7 @@ jobs:
     name: Goreleaser
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: goreleaser/goreleaser-action@v2
+      - uses: actions/checkout@v4
+      - uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1
         with:
           args: release --snapshot --skip=publish --clean

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+      - prepare-release
 jobs:
   test:
     name: Test go${{ matrix.goVersion}}.x ${{ matrix.goArch }}

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,0 +1,108 @@
+name: Build and Publish Python Package
+
+# Be very careful granting extra permissions here, as this workflow uses third party actions.
+# Prefer to pin to exact commits for third-party actions. I'm making an exception for actions
+# maintained by GitHub itself.
+
+# For now, just trigger this workflow manually.
+on:
+  workflow_dispatch:
+    inputs:
+      upload_to_pypi:
+        description: "Upload generate package files to PyPI"
+        required: true
+        type: boolean
+      pypi_environment:
+        description: "Which PyPI instance to publish to"
+        required: true
+        type: choice
+        options:
+          - testpypi
+          - pypi
+
+jobs:
+  build_sdist:
+    name: Build Python sdist
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - run: pip install 'build==1.2.2'
+
+      - name: Build sdist
+        run: python3 -m build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: ./dist/*.gz
+          if-no-files-found: error
+
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        #os: [ubuntu-22.04, windows-latest, macos-latest]
+        os: [ubuntu-22.04, windows-latest]
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@ee63bf16da6cddfb925f542f2c7b59ad50e93969 # v2.22.0
+        env:
+          # Skip PyPy, 32-bit Windows, 32-bit Linux, and CPython before 3.9.
+          # See https://cibuildwheel.readthedocs.io/en/stable/options/#examples_1
+          CIBW_SKIP: "*-win32 pp* *-manylinux_i686 *-musllinux_i686 cp36-* cp37-* cp38-*"
+          CIBW_TEST_COMMAND: >
+            python {package}/python/_jsonnet_test.py
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+          if-no-files-found: error
+
+  upload_to_pypi:
+    name: "Upload packages to PyPI"
+    needs: [build_sdist, build_wheels]
+    runs-on: ubuntu-24.04
+    if: "${{ inputs.upload_to_pypi }}"
+    permissions:
+      contents: read
+      id-token: write # Needed for PyPI Trusted Publishing
+    environment:
+      name: "${{ inputs.pypi_environment }}"
+      url: "${{ inputs.pypi_environment == 'pypi' && 'https://pypi.org/p/gosonnet' || 'https://test.pypi.org/p/gosonnet' }}"
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: cibw-wheels
+          pattern: cibw-wheels-*
+      - uses: actions/download-artifact@v4
+        with:
+          path: sdist
+          name: sdist
+      - name: Flatten wheels to one directory
+        run: |
+          mkdir dist
+          find cibw-wheels/ -type f -name '*.whl' -exec mv '{}' ./dist/ ';'
+          find sdist/ -type f -name '*.gz' -exec mv '{}' ./dist/ ';'
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        with:
+          verbose: true
+          print-hash: true
+          repository-url: "${{ inputs.pypi_environment == 'testpypi' && 'https://test.pypi.org/legacy/' || '' }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,25 +6,22 @@ name: goreleaser
 on:
   push:
     tags:
-      - '*'
+      - "*"
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
-        uses: actions/setup-go@v2
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
           go-version: 1.20
-      -
-        name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1
         with:
           version: latest
           args: release --rm-dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,12 @@
 name: goreleaser
 
 on:
-  push:
-    tags:
-      - "*"
+  workflow_dispatch:
+    inputs:
+      prerelease:
+        description: If set, publish this as a release candidate / prerelease version.
+        type: boolean
+        required: true
 
 jobs:
   release:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -81,7 +81,6 @@ builds:
     main: ./cmd/jsonnet-deps
     binary: jsonnet-deps
 
-
 archives:
   - name_template: >-
       {{- .ProjectName }}_
@@ -93,6 +92,10 @@ archives:
 
 checksum:
   name_template: "checksums.txt"
+
+release:
+  draft: true
+  skip_upload: false
 
 nfpms:
   - id: jsonnet
@@ -145,7 +148,7 @@ nfpms:
           # See: https://packages.ubuntu.com/jsonnet
           - jsonnet-lint
   - id: jsonnet-deps
-    package_name:  jsonnet-deps-go
+    package_name: jsonnet-deps-go
     builds:
       - jsonnet-deps
     homepage: https://github.com/google/go-jsonnet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
- Pull in publish-python.yml from C++ jsonnet.
- Update to newer versions of various referenced GitHub Actions
- Minor changes to goreleaser configuration.
- Explicitly limit ci.yml to read-only permissions.
- Trigger release workflow manually, not on push-to-tag.