### PR TITLE
CI: Build gojsonnet Python wheels on Mac OS

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -54,7 +54,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, macos-13, macos-latest]
+        # Windows Wheel build doesn't work yet.
+        # os: [windows-2022]
 
     permissions:
       contents: read
@@ -63,6 +65,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+
+      - uses: actions/setup-go@v5
+        # Linux runner doesn't need Go setup because it's installed
+        # separately in each cibuildwheel build container
+        if: "${{ runner.os != 'Linux' }}"
+        with:
+          go-version: "1.23.7"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@ee63bf16da6cddfb925f542f2c7b59ad50e93969 # v2.22.0


### PR DESCRIPTION
Use the GitHub setup-go action to install Go, as it is not in the Mac OS runner images by default.

I tried but failed to get a Windows wheel build working, so that remains disabled for now.