### PR TITLE
Fixes for the Bazel module

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,1 +1,2 @@
 cpp-jsonnet
+examples/bazel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,25 @@ jobs:
       - run: bazelisk build --lockfile_mode=error //...
       - run: bazelisk test --lockfile_mode=error //...
 
+  bazel_module_example:
+    name: bazel module example test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/bazel
+            ~/.cache/bazelisk
+          key: ${{ runner.os }}-bazel-cache
+      - run: |
+          # We leave the lockfile off for this. lockfile_mode=off is also
+          # set in the .bazelrc in the examples/bazel/ directory.
+          # The example directly references the local jsonnet_go module from
+          # its parent directory, so the hash will change on almost every
+          # commit anyway.
+          cd examples/bazel && bazelisk build --lockfile_mode=off //...
+
   all:
     name: Check all
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -8,11 +8,7 @@ coverage.out
 build/
 dist/
 gojsonnet.egg-info/
-/bazel-bin
-/bazel-genfiles
-/bazel-go-jsonnet
-/bazel-out
-/bazel-testlogs
+bazel-*
 /dumpstdlibast
 
 # built binaries

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -33,10 +33,7 @@ bazel_dep(name = "gazelle", version = "0.42.0", repo_name = "bazel_gazelle")
 bazel_dep(name = "rules_go", version = "0.53.0", repo_name = "io_bazel_rules_go")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(
-    name = "go_sdk",
-    version = "1.23.7",
-)
+go_sdk.download(version = "1.23.7")
 
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "@jsonnet_go//:go.mod")

--- a/examples/bazel/.bazelrc
+++ b/examples/bazel/.bazelrc
@@ -1,0 +1,1 @@
+common --lockfile_mode=off

--- a/examples/bazel/.gitignore
+++ b/examples/bazel/.gitignore
@@ -1,0 +1,1 @@
+MODULE.bazel.lock

--- a/examples/bazel/BUILD.bazel
+++ b/examples/bazel/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@gazelle//:def.bzl", "gazelle")
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+gazelle(name = "gazelle")
+
+go_library(
+    name = "use_go_jsonnet_lib",
+    srcs = ["use_go_jsonnet.go"],
+    importpath = "github.com/google/go-jsonnet/examples/bazel",
+    visibility = ["//visibility:private"],
+    deps = ["@com_github_google_go_jsonnet//:go_default_library"],
+)
+
+go_binary(
+    name = "use_go_jsonnet",
+    embed = [":use_go_jsonnet_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/examples/bazel/MODULE.bazel
+++ b/examples/bazel/MODULE.bazel
@@ -1,0 +1,22 @@
+bazel_dep(name = "gazelle", version = "0.42.0")
+bazel_dep(name = "rules_go", version = "0.53.0")
+bazel_dep(name = "jsonnet_go")
+local_path_override(
+    module_name = "jsonnet_go",
+    path = "../..",
+)
+
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.23.7")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_google_go_jsonnet",
+)
+
+override_repo(
+    go_deps,
+    com_github_google_go_jsonnet = "jsonnet_go",
+)

--- a/examples/bazel/example.jsonnet
+++ b/examples/bazel/example.jsonnet
@@ -1,0 +1,8 @@
+local Person(name='Alice') = {
+  name: name,
+  welcome: 'Hello ' + name + '!',
+};
+{
+  person1: Person(),
+  person2: Person('Bob'),
+}

--- a/examples/bazel/go.mod
+++ b/examples/bazel/go.mod
@@ -1,0 +1,13 @@
+module example/go-jsonnet-using-bazel
+
+go 1.23.7
+
+require github.com/google/go-jsonnet v0.21.0-rc2
+
+require (
+	golang.org/x/crypto v0.36.0 // indirect
+	golang.org/x/sys v0.31.0 // indirect
+	sigs.k8s.io/yaml v1.4.0 // indirect
+)
+
+replace github.com/google/go-jsonnet => ../../

--- a/examples/bazel/go.sum
+++ b/examples/bazel/go.sum
@@ -1,0 +1,12 @@
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
+github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
+golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
+golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
+sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=

--- a/examples/bazel/use_go_jsonnet.go
+++ b/examples/bazel/use_go_jsonnet.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+
+	gjs "github.com/google/go-jsonnet"
+)
+
+func main() {
+	fmt.Printf("Example using go jsonnet (%s)\n", gjs.Version())
+
+	vm := gjs.MakeVM()
+	out, err := vm.EvaluateFile("example.jsonnet")
+	if err != nil {
+		fmt.Printf("%v\n", err)
+	} else {
+		fmt.Printf("%s", out)
+	}
+}


### PR DESCRIPTION
Attempting to update the Bazel registry for 0.21.0-rc2 (https://github.com/bazelbuild/bazel-central-registry/pull/4015) revealed a problem.

The rules_go go_sdk.download module extension function should not be given a name= attribute; that is only allowed in a root module, so it works for building just go-jsonnet but does not work when the jsonnet_go Bazel module is imported for use in another Bazel module.