### PR TITLE
fix: Unchecked error in std.manifestYamlDoc().

### DIFF
--- a/builtins.go
+++ b/builtins.go
@@ -2264,7 +2264,9 @@ func builtinManifestYamlDoc(i *interpreter, arguments []value) (value, error) {
 				} else {
 					buf.WriteByte(' ')
 				}
-				aux(fieldValue, buf, cindent)
+				if err := aux(fieldValue, buf, cindent); err != nil {
+					return err
+				}
 				cindent = prevIndent
 			}
 		}


### PR DESCRIPTION
Problem: A recursive call within manifestYamlDoc() might fail but the return value is not checked.

Reproducible with:
```
$ jsonnet-2f73f61 -e "std.manifestYamlDoc({ x: { y: error 'foo' } }, quote_keys=false)"
"x:\n  "
```

Expected:
```
$ jsonnet-0.20.0 -e "std.manifestYamlDoc({ x: { y: error 'foo' } }, quote_keys=false)"
RUNTIME ERROR: foo
	<cmdline>:1:31-42	object <anonymous>
	...
```