### PR TITLE
fix: Missing trailing newline when using both --multi and --string options

### DIFF
--- a/interpreter.go
+++ b/interpreter.go
@@ -914,7 +914,7 @@ func (i *interpreter) manifestAndSerializeMulti(v value, stringOutputMode bool) 
 			if stringOutputMode {
 				switch val := fileJSON.(type) {
 				case string:
-					r[filename] = val
+					r[filename] = val + "\n"
 				default:
 					msg := fmt.Sprintf("multi mode: top-level object's key %s has a value of type %T, "+
 						"should be a string", filename, val)


### PR DESCRIPTION
### Problem
when using both `--multi` and `--string` options, the output does not have a trailing newline.

The output has trailing newline when
- using neither  `--multi` or `--string` option
- using only  `--multi` option
- using only `--string` option

### Reproducible with:
```
$ jsonnet-v0.21.0 -e '{"outfile": "x"}' --multi . --string && cat outfile | xxd
00000000: 78                                       x
```
`xxd` shows that the outfile ends with 0x78 or the `x` character.

### Expected:
```
$ jsonnet -e '{"output.json": "xxxxx"}' -m . -S && tail ms.json -c 1 | xxd
00000000: 780a                                     x.
```
`xxd` shows that the outfile ends with 0x0a which is the newline/line-feed (LF) character.

Closes https://github.com/google/go-jsonnet/issues/518