### PR TITLE
chore: fix bazel example

### DIFF
--- a/examples/bazel/BUILD.bazel
+++ b/examples/bazel/BUILD.bazel
@@ -14,5 +14,6 @@ go_library(
 go_binary(
     name = "use_go_jsonnet",
     embed = [":use_go_jsonnet_lib"],
+    data = ["example.jsonnet"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
One bazel example was added in https://github.com/google/go-jsonnet/pull/798 to use as part of CI to verify `bazel build` keeps working. However, the example doesn't work if run with `bazel run` locally, because it doesn't include the example jsonnet file as `data`. This probably doesn't matter since the CI only cares about `bazel build`. However, since people may come here to  get an idea of how to use bazel with jsonnet, it's probably nicer just to make the `bazel run` command able to run as well.