### PR TITLE
Make CI build the bazel example with multiple Bazel versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - master
       - prepare-release
+  # Support triggering the CI workflow manually.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -67,6 +69,10 @@ jobs:
   bazel_module_example:
     name: bazel module example test
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        bazel_version: ["7.*", "8.*", "9.*"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -75,7 +81,10 @@ jobs:
             ~/.cache/bazel
             ~/.cache/bazelisk
           key: ${{ runner.os }}-bazel-cache
-      - run: |
+      - name: Build
+        env:
+          USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
+        run: |
           # We leave the lockfile off for this. lockfile_mode=off is also
           # set in the .bazelrc in the examples/bazel/ directory.
           # The example directly references the local jsonnet_go module from


### PR DESCRIPTION
The bazel example shows how to use go-jsonnet from some other bazel module. Ideally we want to support multiple Bazel versions for this, so try building the example with multiple versions.