### PR TITLE
chore: remove Go Releaser archive naming overrides

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -81,15 +81,6 @@ builds:
     main: ./cmd/jsonnet-deps
     binary: jsonnet-deps
 
-archives:
-  - name_template: >-
-      {{- .ProjectName }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end -}}
-
 checksum:
   name_template: "checksums.txt"
 


### PR DESCRIPTION
Fixes #814