### PR TITLE
feat: add --wrap flag to apply a jsonnet expression to the top-level value

### DIFF
--- a/cmd/jsonnet/cmd.go
+++ b/cmd/jsonnet/cmd.go
@@ -52,6 +52,8 @@ func usage(o io.Writer) {
 	fmt.Fprintln(o, "                             files")
 	fmt.Fprintln(o, "  -y / --yaml-stream         Write output as a YAML stream of JSON documents")
 	fmt.Fprintln(o, "  -S / --string              Expect a string, manifest as plain text")
+	fmt.Fprintln(o, "  --wrap <expr>              Apply <expr> to the top-level value before output,")
+	fmt.Fprintln(o, "                             e.g. --wrap std.manifestYamlDoc")
 	fmt.Fprintln(o, "  --no-trailing-newline      Do not add a trailing newline to the output")
 	fmt.Fprintln(o, "  -s / --max-stack <n>       Number of allowed stack frames")
 	fmt.Fprintln(o, "  -t / --max-trace <n>       Max length of stack trace before cropping")
@@ -102,6 +104,7 @@ type config struct {
 	evalMulti            bool
 	evalStream           bool
 	evalCreateOutputDirs bool
+	wrapExpr             string
 }
 
 func makeConfig() config {
@@ -258,6 +261,12 @@ func processArgs(givenArgs []string, config *config, vm *jsonnet.VM) (processArg
 			config.evalStream = true
 		} else if arg == "-S" || arg == "--string" {
 			vm.StringOutput = true
+		} else if arg == "--wrap" {
+			wrapExpr := cmd.NextArg(&i, args)
+			if len(wrapExpr) == 0 {
+				return processArgsStatusFailure, fmt.Errorf("--wrap argument was empty string")
+			}
+			config.wrapExpr = wrapExpr
 		} else if arg == "--no-trailing-newline" {
 			vm.OutputNewline = false
 		} else if len(arg) > 1 && arg[0] == '-' {
@@ -271,6 +280,18 @@ func processArgs(givenArgs []string, config *config, vm *jsonnet.VM) (processArg
 	// so we explicitly reject it to prevent people from relying on it.
 	if config.evalStream && !vm.OutputNewline {
 		return processArgsStatusFailure, fmt.Errorf("cannot use --no-trailing-newline with --yaml-stream")
+	}
+
+	if config.wrapExpr != "" {
+		if config.evalMulti {
+			return processArgsStatusFailure, fmt.Errorf("cannot use --wrap with --multi")
+		}
+		if config.evalStream {
+			return processArgsStatusFailure, fmt.Errorf("cannot use --wrap with --yaml-stream")
+		}
+		if vm.StringOutput {
+			return processArgsStatusFailure, fmt.Errorf("cannot use --wrap with --string")
+		}
 	}
 
 	want := "filename"
@@ -513,7 +534,18 @@ func main() {
 	var output string
 	var outputArray []string
 	var outputDict map[string]string
-	if config.filenameIsCode || config.inputFiles[0] == "-" {
+	if config.wrapExpr != "" {
+		// Build a snippet that applies the wrap expression to the top-level value.
+		var valueExpr string
+		if config.filenameIsCode || config.inputFiles[0] == "-" {
+			valueExpr = "(" + input + ")"
+		} else {
+			escaped := strings.ReplaceAll(filename, "'", "''")
+			valueExpr = "import @'" + escaped + "'"
+		}
+		vm.StringOutput = true
+		output, err = vm.EvaluateAnonymousSnippet(filename, "("+config.wrapExpr+")("+valueExpr+")")
+	} else if config.filenameIsCode || config.inputFiles[0] == "-" {
 		if config.evalMulti {
 			outputDict, err = vm.EvaluateAnonymousSnippetMulti(filename, input)
 		} else if config.evalStream {

--- a/jsonnet_test.go
+++ b/jsonnet_test.go
@@ -251,6 +251,33 @@ func TestExtReset(t *testing.T) {
 	}
 }
 
+func TestWrapSnippet(t *testing.T) {
+	// Test the snippet pattern used by --wrap: (wrapExpr)(valueExpr)
+	// This mirrors what cmd/jsonnet builds when --wrap is given.
+	vm := MakeVM()
+	vm.StringOutput = true
+
+	// Default quote_keys=true
+	output, err := vm.EvaluateAnonymousSnippet("test.jsonnet",
+		"(std.manifestYamlDoc)({a: 1, b: [1, 2, 3]})")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(output, `"a": 1`) {
+		t.Errorf("expected quoted YAML key by default, got: %s", output)
+	}
+
+	// With quote_keys=false via lambda
+	output2, err := vm.EvaluateAnonymousSnippet("test.jsonnet",
+		"(function(x) std.manifestYamlDoc(x, quote_keys=false))({a: 1, b: [1, 2, 3]})")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(output2, "a: 1") || strings.Contains(output2, `"a"`) {
+		t.Errorf("expected unquoted YAML keys with quote_keys=false, got: %s", output2)
+	}
+}
+
 func TestTLAReset(t *testing.T) {
 	vm := MakeVM()
 	vm.TLAVar("fooString", "bar")


### PR DESCRIPTION
Closes #195.

## Motivation

My primary use case is emitting YAML output directly from jsonnet, without piping through an external converter. The `--wrap` flag makes this possible with `--wrap std.manifestYamlDoc`, while also being general enough to support any output format via stdlib or custom functions.

## Summary

Adds a `--wrap <expr>` flag that applies a jsonnet expression to the top-level evaluated value before output, with string output mode implied.

This is the "simple wrapping" variant discussed in #195 — it constructs a snippet `(expr)(value)` and evaluates it with string output. This is equivalent to the existing `jsonnet -S -e 'std.manifestINI(import "file.jsonnet")'` pattern but more convenient.

## Known limitation: stack traces

As discussed in #195, when an error occurs during manifestation through a stdlib function like `std.manifestYamlDoc`, the stack trace includes stdlib internals, which is noisier than errors during normal evaluation. A future enhancement could add a "deep evaluation" variant that fully evaluates the value before passing it to the manifester, producing cleaner error traces for the custom manifester use case.

## Examples

```sh
# YAML output
jsonnet --wrap std.manifestYamlDoc file.jsonnet

# YAML without quoted keys
jsonnet --wrap 'function(x) std.manifestYamlDoc(x, quote_keys=false)' file.jsonnet

# Pretty JSON via stdlib
jsonnet --wrap std.manifestJson file.jsonnet

# Extract a single field for use in shell scripts
jsonnet --wrap 'function(x) x.version' file.jsonnet
```

## Notes

- `--wrap` is incompatible with `--multi`, `--yaml-stream`, and `--string`
- For file input, builds `(expr)(import @'file')` as a snippet
- For `-e` / stdin, inlines the input as `(expr)(input)`
- The wrap expression must evaluate to a function of one argument

## Test plan

- [x] `jsonnet --wrap std.manifestYamlDoc file.jsonnet` produces YAML
- [x] `jsonnet --wrap 'function(x) std.manifestYamlDoc(x, quote_keys=false)' file.jsonnet` produces unquoted-key YAML
- [x] Works with stdin (`-`) and `-e` code input
- [x] `--wrap` + `--multi` / `--yaml-stream` / `--string` each produce a clear error