### PR TITLE
fix: add depth limit to prevent parser crash

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -42,9 +42,12 @@ func locFromTokenAST(begin *token, end ast.Node) ast.LocationRange {
 
 // ---------------------------------------------------------------------------
 
+const maxParseDepth = 500
+
 type parser struct {
-	t     Tokens
-	currT int
+	t          Tokens
+	currT      int
+	parseDepth int
 }
 
 func makeParser(t Tokens) *parser {
@@ -981,6 +984,14 @@ func (p *parser) parsingFailure(msg string, tok *token) (ast.Node, errors.Static
 }
 
 func (p *parser) parse(prec iast.Precedence) (ast.Node, errors.StaticError) {
+	p.parseDepth++
+	defer func() { p.parseDepth-- }()
+	if p.parseDepth > maxParseDepth {
+		return nil, errors.MakeStaticError(
+			fmt.Sprintf("Exceeded max parse depth of %d", maxParseDepth),
+			p.peek().loc)
+	}
+
 	begin := p.peek()
 
 	switch begin.kind {


### PR DESCRIPTION
Fixes https://github.com/google/go-jsonnet/issues/870
Deeply nested input exhausts the goroutine stack, causing an unrecoverable fatal error that bypasses recover(). Add a depth counter to parse() with a limit of 500 (matching MaxStack).