### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/builtins.go
+++ b/builtins.go
@@ -1574,7 +1574,7 @@ func builtinParseJSON(i *interpreter, str value) (value, error) {
 		return nil, err
 	}
 	s := sval.getGoString()
-	var parsedJSON interface{}
+	var parsedJSON any
 	err = json.Unmarshal([]byte(s), &parsedJSON)
 	if err != nil {
 		return nil, i.Error(fmt.Sprintf("failed to parse JSON: %v", err.Error()))
@@ -1589,10 +1589,10 @@ func builtinParseYAML(i *interpreter, str value) (value, error) {
 	}
 	s := sval.getGoString()
 
-	elems := []interface{}{}
+	elems := []any{}
 	d := NewYAMLToJSONDecoder(strings.NewReader(s))
 	for {
-		var elem interface{}
+		var elem any
 		if err := d.Decode(&elem); err != nil {
 			if err == io.EOF {
 				break
@@ -1611,7 +1611,7 @@ func builtinParseYAML(i *interpreter, str value) (value, error) {
 	return jsonToValue(i, elems[0])
 }
 
-func jsonEncode(v interface{}) (string, error) {
+func jsonEncode(v any) (string, error) {
 	buf := new(bytes.Buffer)
 	enc := json.NewEncoder(buf)
 	enc.SetEscapeHTML(false)

--- a/c-bindings/c-bindings.go
+++ b/c-bindings/c-bindings.go
@@ -27,7 +27,7 @@ type vm struct {
 }
 
 type jsonValue struct {
-	val interface{}
+	val any
 	// these objects are exclusively owned by this jsonValue
 	owned []*C.struct_JsonnetJsonValue
 }
@@ -335,7 +335,7 @@ func jsonnet_native_callback(vmRef *C.struct_JsonnetVm, name *C.char, cb *C.Json
 	f := &jsonnet.NativeFunction{
 		Name:   C.GoString(name),
 		Params: paramNames,
-		Func: func(x []interface{}) (interface{}, error) {
+		Func: func(x []any) (any, error) {
 			var (
 				arr     []*C.struct_JsonnetJsonValue
 				argv    **C.struct_JsonnetJsonValue
@@ -460,13 +460,13 @@ func jsonnet_json_make_null(vmRef *C.struct_JsonnetVm) *C.struct_JsonnetJsonValu
 
 //export jsonnet_json_make_array
 func jsonnet_json_make_array(vmRef *C.struct_JsonnetVm) *C.struct_JsonnetJsonValue {
-	return createJSONValue(vmRef, []interface{}{})
+	return createJSONValue(vmRef, []any{})
 }
 
 //export jsonnet_json_array_append
 func jsonnet_json_array_append(vmRef *C.struct_JsonnetVm, arr *C.struct_JsonnetJsonValue, v *C.struct_JsonnetJsonValue) {
 	json := getJSONValue(arr)
-	slice, ok := json.val.([]interface{})
+	slice, ok := json.val.([]any)
 
 	if !ok {
 		fmt.Fprintf(os.Stderr, "array should be provided")
@@ -479,7 +479,7 @@ func jsonnet_json_array_append(vmRef *C.struct_JsonnetVm, arr *C.struct_JsonnetJ
 
 //export jsonnet_json_make_object
 func jsonnet_json_make_object(vmRef *C.struct_JsonnetVm) *C.struct_JsonnetJsonValue {
-	return createJSONValue(vmRef, make(map[string]interface{}))
+	return createJSONValue(vmRef, make(map[string]any))
 }
 
 //export jsonnet_json_object_append
@@ -490,7 +490,7 @@ func jsonnet_json_object_append(
 	v *C.struct_JsonnetJsonValue,
 ) {
 	d := getJSONValue(obj)
-	table, ok := d.val.(map[string]interface{})
+	table, ok := d.val.(map[string]any)
 
 	if !ok {
 		fmt.Fprintf(os.Stderr, "object should be provided")
@@ -515,7 +515,7 @@ func jsonnet_json_destroy(vmRef *C.struct_JsonnetVm, v *C.struct_JsonnetJsonValu
 	C.jsonnet_internal_free_json(v)
 }
 
-func createJSONValue(vmRef *C.struct_JsonnetVm, val interface{}) *C.struct_JsonnetJsonValue {
+func createJSONValue(vmRef *C.struct_JsonnetVm, val any) *C.struct_JsonnetJsonValue {
 	id, err := handles.make(&jsonValue{val: val})
 
 	if err != nil {

--- a/c-bindings/handles.go
+++ b/c-bindings/handles.go
@@ -21,7 +21,7 @@ type handlesTable struct {
 }
 
 type handle struct {
-	ref interface{}
+	ref any
 }
 
 // errInvalidHandle tells that there was an attempt to dereference invalid handle ID
@@ -34,7 +34,7 @@ func newHandlesTable() handlesTable {
 }
 
 // make registers the new object as a handle and returns the corresponding ID
-func (h *handlesTable) make(obj interface{}) (uintptr, error) {
+func (h *handlesTable) make(obj any) (uintptr, error) {
 	entry := &handle{ref: obj}
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -56,7 +56,7 @@ func (h *handlesTable) free(id uintptr) error {
 }
 
 // get returns the corresponding object for the provided ID
-func (h *handlesTable) get(id uintptr) (interface{}, error) {
+func (h *handlesTable) get(id uintptr) (any, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if handle := h.handles[id]; handle != nil {

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -48,7 +48,7 @@ func processObjectParam(name string, value js.Value) (map[string]string, error) 
 	return result, nil
 }
 
-func jsonnetEvaluateSnippet(this js.Value, p []js.Value) (interface{}, error) {
+func jsonnetEvaluateSnippet(this js.Value, p []js.Value) (any, error) {
 	if len(p) != 7 {
 		return "", fmt.Errorf("wrong number of parameters: %d", len(p))
 	}
@@ -99,7 +99,7 @@ func jsonnetEvaluateSnippet(this js.Value, p []js.Value) (interface{}, error) {
 	return vm.EvaluateAnonymousSnippet(filename, code)
 }
 
-func jsonnetFmtSnippet(this js.Value, p []js.Value) (interface{}, error) {
+func jsonnetFmtSnippet(this js.Value, p []js.Value) (any, error) {
 	if len(p) != 2 {
 		return "", fmt.Errorf("wrong number of parameters: %d", len(p))
 	}
@@ -118,9 +118,9 @@ func jsonnetFmtSnippet(this js.Value, p []js.Value) (interface{}, error) {
 // promiseFuncOf is like js.FuncOf but returns a promise.
 // The promise is able to propagate errors naturally across the wasm /
 // javascript bridge.
-func promiseFuncOf(jsFunc func(this js.Value, p []js.Value) (interface{}, error)) js.Func {
-	return js.FuncOf(func(this js.Value, p []js.Value) interface{} {
-		return js.Global().Get("Promise").New(js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+func promiseFuncOf(jsFunc func(this js.Value, p []js.Value) (any, error)) js.Func {
+	return js.FuncOf(func(this js.Value, p []js.Value) any {
+		return js.Global().Get("Promise").New(js.FuncOf(func(this js.Value, args []js.Value) any {
 			resolve := args[0]
 			reject := args[1]
 			go func() {

--- a/error_formatter.go
+++ b/error_formatter.go
@@ -38,7 +38,7 @@ type ErrorFormatter interface {
 }
 
 // ColorFormatter represents a function that writes to the terminal using color.
-type ColorFormatter func(w io.Writer, f string, a ...interface{}) (n int, err error)
+type ColorFormatter func(w io.Writer, f string, a ...any) (n int, err error)
 
 var _ ErrorFormatter = &termErrorFormatter{}
 

--- a/internal/dump/dump.go
+++ b/internal/dump/dump.go
@@ -165,7 +165,7 @@ func (s *dumpState) dumpMap(v reflect.Value) {
 	mustWrite(s.w, []byte("}"))
 }
 
-func (s *dumpState) dump(value interface{}) {
+func (s *dumpState) dump(value any) {
 	writeVar := func() {
 		if s.config.VariableDescription != "" {
 			fmt.Fprintf(s.w, "\n// %s\n", s.config.VariableDescription)
@@ -497,7 +497,7 @@ func (s *dumpState) visitPointerAndCheckIfFirstTime(v reflect.Value) bool {
 }
 
 // prepares a new state object for dumping the provided value
-func newDumpState(value interface{}, options *Options) *dumpState {
+func newDumpState(value any, options *Options) *dumpState {
 	result := &dumpState{
 		config: options,
 	}
@@ -512,17 +512,17 @@ func newDumpState(value interface{}, options *Options) *dumpState {
 }
 
 // Dump a value to stdout
-func Dump(value interface{}) {
+func Dump(value any) {
 	(&Config).Dump(value)
 }
 
 // Sdump dumps a value to a string
-func Sdump(value interface{}) string {
+func Sdump(value any) string {
 	return (&Config).Sdump(value)
 }
 
 // Dump a value to stdout according to the options
-func (o Options) Dump(value interface{}) {
+func (o Options) Dump(value any) {
 
 	state := newDumpState(value, &o)
 	state.w = os.Stdout
@@ -530,7 +530,7 @@ func (o Options) Dump(value interface{}) {
 }
 
 // Sdump dumps a value to a string according to the options
-func (o Options) Sdump(value interface{}) string {
+func (o Options) Sdump(value any) string {
 	buf := new(bytes.Buffer)
 
 	state := newDumpState(value, &o)

--- a/internal/dump/dump_test.go
+++ b/internal/dump/dump_test.go
@@ -23,124 +23,124 @@ import (
 func TestSdumpPrimitives(t *testing.T) {
 	testcases := []struct {
 		name     string
-		input    func() interface{}
+		input    func() any
 		expected string
 	}{
 		{
 			"boolTrue",
-			func() interface{} {
+			func() any {
 				return true
 			},
 			"var Obj = true\n",
 		},
 		{
 			"boolFalse",
-			func() interface{} {
+			func() any {
 				return false
 			},
 			"var Obj = false\n",
 		},
 		{
 			"int",
-			func() interface{} {
+			func() any {
 				return 10
 			},
 			"var Obj = int(10)\n",
 		},
 		{
 			"int8",
-			func() interface{} {
+			func() any {
 				return int8(10)
 			},
 			"var Obj = int8(10)\n",
 		},
 		{
 			"int16",
-			func() interface{} {
+			func() any {
 				return int16(10)
 			},
 			"var Obj = int16(10)\n",
 		},
 		{
 			"int32",
-			func() interface{} {
+			func() any {
 				return int32(10)
 			},
 			"var Obj = int32(10)\n",
 		},
 		{
 			"int64",
-			func() interface{} {
+			func() any {
 				return int64(10)
 			},
 			"var Obj = int64(10)\n",
 		},
 		{
 			"uint",
-			func() interface{} {
+			func() any {
 				return uint(10)
 			},
 			"var Obj = uint(10)\n",
 		},
 		{
 			"uint8",
-			func() interface{} {
+			func() any {
 				return uint8(10)
 			},
 			"var Obj = uint8(10)\n",
 		},
 		{
 			"uint16",
-			func() interface{} {
+			func() any {
 				return uint16(10)
 			},
 			"var Obj = uint16(10)\n",
 		},
 		{
 			"uint32",
-			func() interface{} {
+			func() any {
 				return uint32(10)
 			},
 			"var Obj = uint32(10)\n",
 		},
 		{
 			"uint64",
-			func() interface{} {
+			func() any {
 				return uint64(10)
 			},
 			"var Obj = uint64(10)\n",
 		},
 		{
 			"float32",
-			func() interface{} {
+			func() any {
 				return float32(10.5)
 			},
 			"var Obj = float32(10.5)\n",
 		},
 		{
 			"float64",
-			func() interface{} {
+			func() any {
 				return float64(10.5)
 			},
 			"var Obj = float64(10.5)\n",
 		},
 		{
 			"complex64",
-			func() interface{} {
+			func() any {
 				return complex64(10 + 10.5i)
 			},
 			"var Obj = complex64(10+10.5i)\n",
 		},
 		{
 			"complex128",
-			func() interface{} {
+			func() any {
 				return complex128(-1.2 - 0.5i)
 			},
 			"var Obj = complex128(-1.2-0.5i)\n",
 		},
 		{
 			"string",
-			func() interface{} {
+			func() any {
 				return "hello world"
 			},
 			"var Obj = \"hello world\"\n",
@@ -158,12 +158,12 @@ func TestSdumpPrimitives(t *testing.T) {
 func TestSdumpPrimitivePointers(t *testing.T) {
 	testcases := []struct {
 		name     string
-		input    func() interface{}
+		input    func() any
 		expected string
 	}{
 		{
 			"booltruepointer",
-			func() interface{} {
+			func() any {
 				var a = true
 				return &a
 			},
@@ -174,7 +174,7 @@ var Obj = p0
 		},
 		{
 			"boolfalsepointer",
-			func() interface{} {
+			func() any {
 				var a = false
 				return &a
 			},
@@ -185,7 +185,7 @@ var Obj = p0
 		},
 		{
 			"intpointer",
-			func() interface{} {
+			func() any {
 				var a = 10
 				return &a
 			},
@@ -196,7 +196,7 @@ var Obj = p0
 		},
 		{
 			"int8pointer",
-			func() interface{} {
+			func() any {
 				var a = int8(10)
 				return &a
 			},
@@ -207,7 +207,7 @@ var Obj = p0
 		},
 		{
 			"int16pointer",
-			func() interface{} {
+			func() any {
 				var a = int16(10)
 				return &a
 			},
@@ -218,7 +218,7 @@ var Obj = p0
 		},
 		{
 			"int32pointer",
-			func() interface{} {
+			func() any {
 				var a = int32(10)
 				return &a
 			},
@@ -229,7 +229,7 @@ var Obj = p0
 		},
 		{
 			"int64pointer",
-			func() interface{} {
+			func() any {
 				var a = int64(10)
 				return &a
 			},
@@ -240,7 +240,7 @@ var Obj = p0
 		},
 		{
 			"uintpointer",
-			func() interface{} {
+			func() any {
 				var a = uint(10)
 				return &a
 			},
@@ -251,7 +251,7 @@ var Obj = p0
 		},
 		{
 			"uint8pointer",
-			func() interface{} {
+			func() any {
 				var a = uint8(10)
 				return &a
 			},
@@ -262,7 +262,7 @@ var Obj = p0
 		},
 		{
 			"uint16pointer",
-			func() interface{} {
+			func() any {
 				var a = uint16(10)
 				return &a
 			},
@@ -273,7 +273,7 @@ var Obj = p0
 		},
 		{
 			"uint32pointer",
-			func() interface{} {
+			func() any {
 				var a = uint32(10)
 				return &a
 			},
@@ -284,7 +284,7 @@ var Obj = p0
 		},
 		{
 			"uint64pointer",
-			func() interface{} {
+			func() any {
 				var a = uint64(10)
 				return &a
 			},
@@ -295,7 +295,7 @@ var Obj = p0
 		},
 		{
 			"float32pointer",
-			func() interface{} {
+			func() any {
 				var a = float32(10.5)
 				return &a
 			},
@@ -306,7 +306,7 @@ var Obj = p0
 		},
 		{
 			"float64pointer",
-			func() interface{} {
+			func() any {
 				var a = float64(10.5)
 				return &a
 			},
@@ -317,7 +317,7 @@ var Obj = p0
 		},
 		{
 			"complex64pointer",
-			func() interface{} {
+			func() any {
 				var a = complex64(10 + 10.5i)
 				return &a
 			},
@@ -328,7 +328,7 @@ var Obj = p0
 		},
 		{
 			"complex128pointer",
-			func() interface{} {
+			func() any {
 				var a = complex128(-1.2 - 0.5i)
 				return &a
 			},
@@ -339,7 +339,7 @@ var Obj = p0
 		},
 		{
 			"stringpointer",
-			func() interface{} {
+			func() any {
 				var a = "hello world"
 				return &a
 			},
@@ -350,7 +350,7 @@ var Obj = p0
 		},
 		{
 			"nilpointer",
-			func() interface{} {
+			func() any {
 				return nil
 			},
 			`var Obj = nil
@@ -358,7 +358,7 @@ var Obj = p0
 		},
 		{
 			"stringnilpointer",
-			func() interface{} {
+			func() any {
 				var a *string
 				return a
 			},
@@ -378,12 +378,12 @@ var Obj = p0
 func TestSdumpReusedPointers(t *testing.T) {
 	testcases := []struct {
 		name     string
-		input    func() interface{}
+		input    func() any
 		expected string
 	}{
 		{
 			"reusedprimitivepointer",
-			func() interface{} {
+			func() any {
 				var a = "hello world"
 				return &struct {
 					Foo *string
@@ -403,7 +403,7 @@ var Obj = &struct { Foo *string; Bar *string }{
 		},
 		{
 			"reusednilpointer",
-			func() interface{} {
+			func() any {
 				var a *string
 				return &struct {
 					Foo *string
@@ -421,7 +421,7 @@ var Obj = &struct { Foo *string; Bar *string }{
 		},
 		{
 			"reusedstructpointer",
-			func() interface{} {
+			func() any {
 				type Zeo struct {
 					A string
 				}

--- a/internal/pass/pass.go
+++ b/internal/pass/pass.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Context can be used to provide context when visting child expressions.
-type Context interface{}
+type Context any
 
 // ASTPass is an interface for a pass that transforms the AST in some way.
 type ASTPass interface {

--- a/interpreter.go
+++ b/interpreter.go
@@ -681,7 +681,7 @@ func unparseNumber(v float64) string {
 }
 
 // manifestJSON converts to standard JSON representation as in "encoding/json" package
-func (i *interpreter) manifestJSON(v value) (interface{}, error) {
+func (i *interpreter) manifestJSON(v value) (any, error) {
 	// TODO(sbarzowski) Add nice stack traces indicating the part of the code which
 	// evaluates to non-manifestable value (that might require passing context about
 	// the root value)
@@ -715,7 +715,7 @@ func (i *interpreter) manifestJSON(v value) (interface{}, error) {
 		return nil, nil
 
 	case *valueArray:
-		result := make([]interface{}, 0, len(v.elements))
+		result := make([]any, 0, len(v.elements))
 		for index, th := range v.elements {
 			msg := ast.MakeLocationRangeMessage(fmt.Sprintf("Array element %d", index))
 			i.stack.setCurrentTrace(traceElement{
@@ -751,7 +751,7 @@ func (i *interpreter) manifestJSON(v value) (interface{}, error) {
 		}
 		i.stack.clearCurrentTrace()
 
-		result := make(map[string]interface{}, len(fieldNames))
+		result := make(map[string]any, len(fieldNames))
 
 		for _, fieldName := range fieldNames {
 			msg := ast.MakeLocationRangeMessage(fmt.Sprintf("Field %#v", fieldName))
@@ -784,12 +784,12 @@ func (i *interpreter) manifestJSON(v value) (interface{}, error) {
 	}
 }
 
-func serializeJSON(v interface{}, multiline bool, indent string, buf *bytes.Buffer) {
+func serializeJSON(v any, multiline bool, indent string, buf *bytes.Buffer) {
 	switch v := v.(type) {
 	case nil:
 		buf.WriteString("null")
 
-	case []interface{}:
+	case []any:
 		if len(v) == 0 {
 			buf.WriteString("[ ]")
 		} else {
@@ -829,7 +829,7 @@ func serializeJSON(v interface{}, multiline bool, indent string, buf *bytes.Buff
 	case float64:
 		buf.WriteString(unparseNumber(v))
 
-	case map[string]interface{}:
+	case map[string]any:
 		fieldNames := make([]string, 0, len(v))
 		for name := range v {
 			fieldNames = append(fieldNames, name)
@@ -909,7 +909,7 @@ func (i *interpreter) manifestAndSerializeMulti(v value, stringOutputMode bool, 
 		return r, err
 	}
 	switch json := json.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		for filename, fileJSON := range json {
 			var buf bytes.Buffer
 			if stringOutputMode {
@@ -945,7 +945,7 @@ func (i *interpreter) manifestAndSerializeYAMLStream(v value) (r []string, err e
 		return r, err
 	}
 	switch json := json.(type) {
-	case []interface{}:
+	case []any:
 		for _, doc := range json {
 			var buf bytes.Buffer
 			serializeJSON(doc, true, "", &buf)
@@ -961,12 +961,12 @@ func (i *interpreter) manifestAndSerializeYAMLStream(v value) (r []string, err e
 	return
 }
 
-func jsonToValue(i *interpreter, v interface{}) (value, error) {
+func jsonToValue(i *interpreter, v any) (value, error) {
 	switch v := v.(type) {
 	case nil:
 		return &nullValue, nil
 
-	case []interface{}:
+	case []any:
 		elems := make([]*cachedThunk, len(v))
 		for counter, elem := range v {
 			val, err := jsonToValue(i, elem)
@@ -992,7 +992,7 @@ func jsonToValue(i *interpreter, v interface{}) (value, error) {
 	case float64:
 		return makeDoubleCheck(i, v)
 
-	case map[string]interface{}:
+	case map[string]any:
 		fieldMap := map[string]value{}
 		for name, f := range v {
 			val, err := jsonToValue(i, f)

--- a/main_test.go
+++ b/main_test.go
@@ -78,7 +78,7 @@ type mainTest struct {
 var jsonToString = &NativeFunction{
 	Name:   "jsonToString",
 	Params: ast.Identifiers{"x"},
-	Func: func(x []interface{}) (interface{}, error) {
+	Func: func(x []any) (any, error) {
 		bytes, err := json.Marshal(x[0])
 		if err != nil {
 			return nil, err
@@ -90,7 +90,7 @@ var jsonToString = &NativeFunction{
 var nativeError = &NativeFunction{
 	Name:   "nativeError",
 	Params: ast.Identifiers{},
-	Func: func(x []interface{}) (interface{}, error) {
+	Func: func(x []any) (any, error) {
 		return nil, errors.New("native function error")
 	},
 }
@@ -98,7 +98,7 @@ var nativeError = &NativeFunction{
 var nativePanic = &NativeFunction{
 	Name:   "nativePanic",
 	Params: ast.Identifiers{},
-	Func: func(x []interface{}) (interface{}, error) {
+	Func: func(x []any) (any, error) {
 		panic("native function panic")
 	},
 }

--- a/thunks.go
+++ b/thunks.go
@@ -256,14 +256,14 @@ func makeClosure(env environment, function *ast.Function) *closure {
 // NativeFunction represents a function implemented in Go.
 type NativeFunction struct {
 	Name   string
-	Func   func([]interface{}) (interface{}, error)
+	Func   func([]any) (any, error)
 	Params ast.Identifiers
 }
 
 // evalCall evaluates a call to a NativeFunction and returns the result.
 func (native *NativeFunction) evalCall(arguments callArguments, i *interpreter) (value, error) {
 	flatArgs := flattenArgs(arguments, native.parameters(), []value{})
-	nativeArgs := make([]interface{}, 0, len(flatArgs))
+	nativeArgs := make([]any, 0, len(flatArgs))
 	for _, arg := range flatArgs {
 		v, err := i.evaluatePV(arg)
 		if err != nil {
@@ -275,7 +275,7 @@ func (native *NativeFunction) evalCall(arguments callArguments, i *interpreter) 
 		}
 		nativeArgs = append(nativeArgs, json)
 	}
-	call := func() (resultJSON interface{}, err error) {
+	call := func() (resultJSON any, err error) {
 		defer func() {
 			if r := recover(); r != nil {
 				err = fmt.Errorf("native function %#v panicked: %v", native.Name, r)

--- a/vm.go
+++ b/vm.go
@@ -231,7 +231,7 @@ func (vm *VM) EvaluateMulti(node ast.Node) (output map[string]string, err error)
 	return evaluateMulti(i, node, vm.tla, vm.StringOutput, vm.OutputNewline)
 }
 
-func (vm *VM) evaluateSnippet(diagnosticFileName ast.DiagnosticFileName, filename string, snippet string, kind evalKind) (output interface{}, err error) {
+func (vm *VM) evaluateSnippet(diagnosticFileName ast.DiagnosticFileName, filename string, snippet string, kind evalKind) (output any, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("(CRASH) %v\n%s", r, debug.Stack())

--- a/yaml.go
+++ b/yaml.go
@@ -45,7 +45,7 @@ func NewYAMLToJSONDecoder(r io.Reader) *YAMLToJSONDecoder {
 // Decode reads a YAML document as JSON from the stream or returns
 // an error. The decoding rules match json.Unmarshal, not
 // yaml.Unmarshal.
-func (d *YAMLToJSONDecoder) Decode(into interface{}) error {
+func (d *YAMLToJSONDecoder) Decode(into any) error {
 	bytes, err := d.reader.read()
 	if err != nil && err != io.EOF {
 		return err


### PR DESCRIPTION
Replace all occurrences of `interface{}` with `any` across the codebase. This is a mechanical refactor using Go 1.18+ syntax, now that the module requires Go 1.24.

Fixes 13 files.