### PR TITLE
Improve runtime error when indexing a non-indexable value

### DIFF
--- a/interpreter.go
+++ b/interpreter.go
@@ -505,7 +505,7 @@ func (i *interpreter) rawevaluate(a ast.Node, tc tailCallStatus) (value, error) 
 			return target.index(i, int(indexInt.value))
 		}
 
-		return nil, i.Error(fmt.Sprintf("Value non indexable: %v", reflect.TypeOf(targetValue)))
+		return nil, i.Error(fmt.Sprintf("Could not index a value of type %q (only objects, arrays and strings can be indexed)", targetValue.getType().name))
 
 	case *ast.Import:
 		codePath := node.Loc().FileName

--- a/jsonnet_test.go
+++ b/jsonnet_test.go
@@ -350,3 +350,32 @@ func TestSetTraceOut(t *testing.T) {
 		t.Errorf("Expected %q, but got %q", expected, actual)
 	}
 }
+
+func TestIndexNonIndexableErrorMessage(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		typeName string
+	}{
+		{name: "null", input: `null[42]`, typeName: "null"},
+		{name: "number", input: `(42)[0]`, typeName: "number"},
+		{name: "boolean", input: `true[0]`, typeName: "boolean"},
+		{name: "function", input: `(function() 1)[0]`, typeName: "function"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			vm := MakeVM()
+			_, err := vm.EvaluateAnonymousSnippet("test.jsonnet", tc.input)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.typeName) {
+				t.Errorf("error %q should mention the jsonnet type %q", err.Error(), tc.typeName)
+			}
+			if strings.Contains(err.Error(), "jsonnet.value") {
+				t.Errorf("error %q should not leak internal Go type names", err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Indexing a non-indexable value produced an error that leaked the internal Go type name:

```
RUNTIME ERROR: Value non indexable: *jsonnet.valueNull
```

This is confusing for users, who have no notion of `*jsonnet.valueNull`. The message now uses the jsonnet type name and explains which types can be indexed:

```
RUNTIME ERROR: Could not index a value of type "null" (only objects, arrays and strings can be indexed)
```

## Changes

- `interpreter.go`: build the error from `targetValue.getType().name` instead of `reflect.TypeOf`, matching how other runtime type errors are reported in this file.
- `jsonnet_test.go`: add a test covering null, number, boolean and function targets, asserting the message mentions the jsonnet type and does not leak internal Go type names.

Fixes #258