### PR TITLE
fix: add stack depth accounting to rawEquals

### DIFF
--- a/builtins.go
+++ b/builtins.go
@@ -614,7 +614,7 @@ func rawMember(i *interpreter, arrv, value value) (bool, error) {
 			if err != nil {
 				return false, err
 			}
-			equal, err := rawEquals(i, cachedThunkValue, value)
+			equal, err := rawEquals(i, cachedThunkValue, value, i.stack.limit)
 			if err != nil {
 				return false, err
 			}
@@ -824,7 +824,10 @@ func primitiveEquals(i *interpreter, x, y value) (value, error) {
 	}
 }
 
-func rawEquals(i *interpreter, x, y value) (bool, error) {
+func rawEquals(i *interpreter, x, y value, depth int) (bool, error) {
+	if depth <= 0 {
+		return false, i.Error("max equality depth exceeded, possible infinite recursion")
+	}
 	if x.getType() != y.getType() {
 		return false, nil
 	}
@@ -866,7 +869,7 @@ func rawEquals(i *interpreter, x, y value) (bool, error) {
 			if err != nil {
 				return false, err
 			}
-			eq, err := rawEquals(i, leftElem, rightElem)
+			eq, err := rawEquals(i, leftElem, rightElem, depth-1)
 			if err != nil {
 				return false, err
 			}
@@ -902,7 +905,7 @@ func rawEquals(i *interpreter, x, y value) (bool, error) {
 			if err != nil {
 				return false, err
 			}
-			eq, err := rawEquals(i, leftField, rightField)
+			eq, err := rawEquals(i, leftField, rightField, depth-1)
 			if err != nil {
 				return false, err
 			}
@@ -918,7 +921,7 @@ func rawEquals(i *interpreter, x, y value) (bool, error) {
 }
 
 func builtinEquals(i *interpreter, x, y value) (value, error) {
-	eq, err := rawEquals(i, x, y)
+	eq, err := rawEquals(i, x, y, i.stack.limit)
 	if err != nil {
 		return nil, err
 	}
@@ -926,7 +929,7 @@ func builtinEquals(i *interpreter, x, y value) (value, error) {
 }
 
 func builtinNotEquals(i *interpreter, x, y value) (value, error) {
-	eq, err := rawEquals(i, x, y)
+	eq, err := rawEquals(i, x, y, i.stack.limit)
 	if err != nil {
 		return nil, err
 	}
@@ -2489,7 +2492,7 @@ func builtinContains(i *interpreter, arrv value, ev value) (value, error) {
 		if err != nil {
 			return nil, err
 		}
-		eq, err := rawEquals(i, val, ev)
+		eq, err := rawEquals(i, val, ev, i.stack.limit)
 		if err != nil {
 			return nil, err
 		}
@@ -2510,7 +2513,7 @@ func builtinRemove(i *interpreter, arrv value, ev value) (value, error) {
 		if err != nil {
 			return nil, err
 		}
-		eq, err := rawEquals(i, val, ev)
+		eq, err := rawEquals(i, val, ev, i.stack.limit)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Problem

`rawEquals` in `builtins.go`, which implements jsonnet's `==` and `!=` operators, recurses natively via the Go call stack when comparing nested arrays or objects. It has no stack-depth accounting anywhere in the call chain.

A self-referential jsonnet value compared with `==`:
```
{a: $} == {a: $}
```
causes `rawEquals` to recurse into itself indefinitely, consuming memory until the process is killed by the OS (OOM) or the Go runtime's stack limit is hit.

## Precedent

This is the same bug class already fixed in `builtinManifestJSONEx`, `builtinManifestYamlDoc`, and `builtinManifestTomlEx` (depth-counter pattern seeded from `i.stack.limit`, decremented per recursive call, erroring with "max manifest depth exceeded"). `rawEquals` was never covered by that sweep and remains vulnerable to the identical trigger pattern.

## Fix

Adds a `depth int` parameter to `rawEquals`, seeded from `i.stack.limit` (the interpreter's own configured stack limit, default 500) at all 5 entry points, and decremented on each of the 2 recursive call sites (array element comparison, object field comparison). Errors with `"max equality depth exceeded, possible infinite recursion"` when exhausted — matching the existing manifest-builtin error message style exactly.

## Testing

Verified with `{a: $} == {a: $}` — with the fix, this now returns a clean error instead of hanging indefinitely with unbounded memory growth.